### PR TITLE
fix: update repo references from paperclipai/paperclip to JavierCervi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <p align="center">
   <a href="#quickstart"><strong>Quickstart</strong></a> &middot;
   <a href="https://paperclip.ing/docs"><strong>Docs</strong></a> &middot;
-  <a href="https://github.com/paperclipai/paperclip"><strong>GitHub</strong></a> &middot;
+  <a href="https://github.com/JavierCervilla/paperclip"><strong>GitHub</strong></a> &middot;
   <a href="https://discord.gg/m4HZY7xNG3"><strong>Discord</strong></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/paperclipai/paperclip/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" /></a>
-  <a href="https://github.com/paperclipai/paperclip/stargazers"><img src="https://img.shields.io/github/stars/paperclipai/paperclip?style=flat" alt="Stars" /></a>
+  <a href="https://github.com/JavierCervilla/paperclip/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" /></a>
+  <a href="https://github.com/JavierCervilla/paperclip/stargazers"><img src="https://img.shields.io/github/stars/JavierCervilla/paperclip?style=flat" alt="Stars" /></a>
   <a href="https://discord.gg/m4HZY7xNG3"><img src="https://img.shields.io/discord/000000000?label=discord" alt="Discord" /></a>
 </p>
 
@@ -180,7 +180,7 @@ npx paperclipai onboard --yes
 Or manually:
 
 ```bash
-git clone https://github.com/paperclipai/paperclip.git
+git clone https://github.com/JavierCervilla/paperclip.git
 cd paperclip
 pnpm install
 pnpm dev
@@ -253,8 +253,8 @@ We welcome contributions. See the [contributing guide](CONTRIBUTING.md) for deta
 ## Community
 
 - [Discord](https://discord.gg/m4HZY7xNG3) — Join the community
-- [GitHub Issues](https://github.com/paperclipai/paperclip/issues) — bugs and feature requests
-- [GitHub Discussions](https://github.com/paperclipai/paperclip/discussions) — ideas and RFC
+- [GitHub Issues](https://github.com/JavierCervilla/paperclip/issues) — bugs and feature requests
+- [GitHub Discussions](https://github.com/JavierCervilla/paperclip/discussions) — ideas and RFC
 
 <br/>
 
@@ -264,7 +264,7 @@ MIT &copy; 2026 Paperclip
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=paperclipai/paperclip&type=date&legend=top-left)](https://www.star-history.com/?repos=paperclipai%2Fpaperclip&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/image?repos=JavierCervilla/paperclip&type=date&legend=top-left)](https://www.star-history.com/?repos=paperclipai%2Fpaperclip&type=date&legend=top-left)
 
 <br/>
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -16,12 +16,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "cli"
   },
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "files": [
     "dist"

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/adapter-utils",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/adapter-utils"
   },
   "type": "module",

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/adapter-claude-local",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/adapters/claude-local"
   },
   "type": "module",

--- a/packages/adapters/codex-local/package.json
+++ b/packages/adapters/codex-local/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/adapter-codex-local",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/adapters/codex-local"
   },
   "type": "module",

--- a/packages/adapters/cursor-local/package.json
+++ b/packages/adapters/cursor-local/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/adapter-cursor-local",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/adapters/cursor-local"
   },
   "type": "module",

--- a/packages/adapters/gemini-local/package.json
+++ b/packages/adapters/gemini-local/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/adapter-gemini-local",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/adapters/gemini-local"
   },
   "type": "module",

--- a/packages/adapters/openclaw-gateway/package.json
+++ b/packages/adapters/openclaw-gateway/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/adapter-openclaw-gateway",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/adapters/openclaw-gateway"
   },
   "type": "module",

--- a/packages/adapters/opencode-local/package.json
+++ b/packages/adapters/opencode-local/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/adapter-opencode-local",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/adapters/opencode-local"
   },
   "type": "module",

--- a/packages/adapters/pi-local/package.json
+++ b/packages/adapters/pi-local/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/adapter-pi-local",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/adapters/pi-local"
   },
   "type": "module",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/db",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/db"
   },
   "type": "module",

--- a/packages/plugins/create-paperclip-plugin/package.json
+++ b/packages/plugins/create-paperclip-plugin/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/create-paperclip-plugin",
   "version": "0.1.0",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/plugins/create-paperclip-plugin"
   },
   "type": "module",

--- a/packages/plugins/sdk/package.json
+++ b/packages/plugins/sdk/package.json
@@ -3,13 +3,13 @@
   "version": "1.0.0",
   "description": "Stable public API for Paperclip plugins — worker-side context and UI bridge hooks",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/plugins/sdk"
   },
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/shared",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "packages/shared"
   },
   "type": "module",

--- a/scripts/clean-onboard-git.sh
+++ b/scripts/clean-onboard-git.sh
@@ -7,7 +7,7 @@ mkdir -p "$PC_HOME" "$PC_CACHE" "$PC_DATA"
 echo "PC_TEST_ROOT: $PC_TEST_ROOT"
 echo "PC_HOME: $PC_HOME"
 cd $PC_TEST_ROOT
-git clone https://github.com/paperclipai/paperclip.git repo
+git clone https://github.com/JavierCervilla/paperclip.git repo
 cd repo
 pnpm install
 env HOME="$PC_HOME" npm_config_cache="$PC_CACHE" npm_config_userconfig="$PC_HOME/.npmrc" \

--- a/server/package.json
+++ b/server/package.json
@@ -2,13 +2,13 @@
   "name": "@paperclipai/server",
   "version": "0.3.1",
   "license": "MIT",
-  "homepage": "https://github.com/paperclipai/paperclip",
+  "homepage": "https://github.com/JavierCervilla/paperclip",
   "bugs": {
-    "url": "https://github.com/paperclipai/paperclip/issues"
+    "url": "https://github.com/JavierCervilla/paperclip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paperclipai/paperclip",
+    "url": "https://github.com/JavierCervilla/paperclip",
     "directory": "server"
   },
   "type": "module",


### PR DESCRIPTION
…lla/paperclip

Update package.json homepage/bugs/repository URLs, README links, and onboarding script clone URL to point to our fork instead of upstream.

Upstream-specific references (sync workflows, agent sync instructions, release automation, branching docs, historical release notes) are intentionally preserved as they correctly reference the upstream repo.

Resolves PAP-44