### PR TITLE
fix: restore 'paperclip' service name in dokploy compose

### DIFF
--- a/deploy/docker-compose.dokploy.yml
+++ b/deploy/docker-compose.dokploy.yml
@@ -33,7 +33,7 @@ services:
       retries: 3
       start_period: 60s
 
-  server:
+  paperclip:
     build:
       context: ..
       dockerfile: Dockerfile


### PR DESCRIPTION
Dokploy expects the service to be named 'paperclip' but commit 168faa1 renamed it to 'server', breaking deployment. Rename it back.