### PR TITLE
ci: add Docker build test on PRs to preview

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,31 @@
+name: Docker Build Test
+
+on:
+  pull_request:
+    branches:
+      - preview
+
+concurrency:
+  group: docker-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (through build stage)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: build
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow (`docker-build-test.yml`) that runs a Docker build on every PR targeting `preview`
- Builds up to the `build` stage (deps install + TypeScript compilation) to validate the Dockerfile without the slow production global installs
- Uses GitHub Actions cache (BuildKit GHA cache) for fast subsequent runs
- 5-minute timeout; build failure blocks merge

Closes PAP-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)