### PR TITLE
feat: enhance /api/health with db check, uptime, and response time

### DIFF
--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -5,12 +5,16 @@ import { healthRoutes } from "../routes/health.js";
 import { serverVersion } from "../version.js";
 
 describe("GET /health", () => {
-  const app = express();
-  app.use("/health", healthRoutes());
+  describe("without db", () => {
+    const app = express();
+    app.use("/health", healthRoutes());
 
-  it("returns 200 with status ok", async () => {
-    const res = await request(app).get("/health");
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok", version: serverVersion });
+    it("returns 200 with status ok and uptime", async () => {
+      const res = await request(app).get("/health");
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("ok");
+      expect(res.body.version).toBe(serverVersion);
+      expect(typeof res.body.uptime).toBe("number");
+    });
   });
 });

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -5,6 +5,8 @@ import { instanceUserRoles, invites } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import { serverVersion } from "../version.js";
 
+const startedAt = Date.now();
+
 export function healthRoutes(
   db?: Db,
   opts: {
@@ -22,14 +24,33 @@ export function healthRoutes(
   const router = Router();
 
   router.get("/", async (_req, res) => {
+    const requestStart = Date.now();
+
     if (!db) {
-      res.json({ status: "ok", version: serverVersion });
+      res.json({
+        status: "ok",
+        version: serverVersion,
+        uptime: Math.floor((Date.now() - startedAt) / 1000),
+      });
       return;
     }
 
+    let dbStatus: "connected" | "disconnected" = "disconnected";
+    let dbLatencyMs: number | null = null;
+    try {
+      const dbStart = Date.now();
+      await db.execute(sql`SELECT 1`);
+      dbLatencyMs = Date.now() - dbStart;
+      dbStatus = "connected";
+    } catch {
+      dbStatus = "disconnected";
+    }
+
+    const healthy = dbStatus === "connected";
+
     let bootstrapStatus: "ready" | "bootstrap_pending" = "ready";
     let bootstrapInviteActive = false;
-    if (opts.deploymentMode === "authenticated") {
+    if (healthy && opts.deploymentMode === "authenticated") {
       const roleCount = await db
         .select({ count: count() })
         .from(instanceUserRoles)
@@ -55,9 +76,17 @@ export function healthRoutes(
       }
     }
 
-    res.json({
-      status: "ok",
+    const responseTimeMs = Date.now() - requestStart;
+
+    res.status(healthy ? 200 : 503).json({
+      status: healthy ? "ok" : "degraded",
       version: serverVersion,
+      uptime: Math.floor((Date.now() - startedAt) / 1000),
+      database: {
+        status: dbStatus,
+        latencyMs: dbLatencyMs,
+      },
+      responseTimeMs,
       deploymentMode: opts.deploymentMode,
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,


### PR DESCRIPTION
## Summary

- Adds database connectivity check with latency measurement to `GET /api/health`
- Returns HTTP 503 with `"degraded"` status when the database is unreachable
- Adds server uptime (seconds) and response time (ms) to the response
- Updates tests to cover the new response shape

Resolves [PAP-10](/PAP/issues/PAP-10) — enables external uptime monitoring and load balancer health checks for Dokploy.

## Test plan

- [x] Unit test passes (`health.test.ts`)
- [ ] Manual verification: hit `GET /api/health` on preview and confirm `database.status`, `uptime`, and `responseTimeMs` fields are present
- [ ] Verify 503 response when DB is down (stop DB container, hit endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)