### PR TITLE
feat: uptime monitoring for production services

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -1,0 +1,104 @@
+name: Uptime Monitor
+
+on:
+  schedule:
+    # Every 5 minutes
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+env:
+  HEALTH_URL: ${{ secrets.PRODUCTION_URL }}/api/health
+  PREVIEW_HEALTH_URL: ${{ secrets.PREVIEW_URL }}/api/health
+
+jobs:
+  check-production:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.PRODUCTION_URL != '' }}
+    steps:
+      - name: Check production health
+        id: health
+        run: |
+          HTTP_CODE=$(curl -s -o /tmp/health.json -w "%{http_code}" \
+            --max-time 30 --connect-timeout 10 \
+            "${{ env.HEALTH_URL }}" || echo "000")
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            echo "Production health check passed (HTTP $HTTP_CODE)"
+            cat /tmp/health.json | jq . 2>/dev/null || cat /tmp/health.json
+          else
+            echo "status=down" >> "$GITHUB_OUTPUT"
+            echo "::error::Production health check FAILED (HTTP $HTTP_CODE)"
+            cat /tmp/health.json 2>/dev/null || true
+          fi
+
+      - name: Create issue on failure
+        if: steps.health.outputs.status == 'down'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `🚨 Production DOWN — HTTP ${process.env.HTTP_CODE} at ${new Date().toISOString()}`;
+            const body = [
+              '## Production Downtime Alert',
+              '',
+              `- **Endpoint:** \`${{ env.HEALTH_URL }}\``,
+              `- **HTTP Status:** ${process.env.HTTP_CODE}`,
+              `- **Checked at:** ${new Date().toISOString()}`,
+              `- **Workflow run:** ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+              '',
+              'Automated alert from uptime monitor workflow.',
+            ].join('\n');
+
+            // Check for existing open downtime issue to avoid duplicates
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'downtime',
+              per_page: 1,
+            });
+
+            if (existing.length > 0) {
+              // Add comment to existing issue instead of creating a new one
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body: `Still down — HTTP ${process.env.HTTP_CODE} at ${new Date().toISOString()}`,
+              });
+              console.log(`Updated existing downtime issue #${existing[0].number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['downtime'],
+              });
+              console.log('Created new downtime issue');
+            }
+        env:
+          HTTP_CODE: ${{ steps.health.outputs.http_code }}
+
+  check-preview:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.PREVIEW_URL != '' }}
+    steps:
+      - name: Check preview health
+        id: health
+        run: |
+          HTTP_CODE=$(curl -s -o /tmp/health.json -w "%{http_code}" \
+            --max-time 30 --connect-timeout 10 \
+            "${{ env.PREVIEW_HEALTH_URL }}" || echo "000")
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "Production preview check passed (HTTP $HTTP_CODE)"
+            cat /tmp/health.json | jq . 2>/dev/null || cat /tmp/health.json
+          else
+            echo "::warning::Preview health check failed (HTTP $HTTP_CODE)"
+          fi

--- a/doc/UPTIME-MONITORING.md
+++ b/doc/UPTIME-MONITORING.md
@@ -1,0 +1,54 @@
+# Uptime Monitoring
+
+Automated uptime monitoring for the Paperclip production and preview instances.
+
+## How It Works
+
+The GitHub Actions workflow `.github/workflows/uptime-monitor.yml` runs every 5 minutes and checks the `/api/health` endpoint on both production and preview.
+
+### What it checks
+
+- HTTP GET to `${PRODUCTION_URL}/api/health` and `${PREVIEW_URL}/api/health`
+- Expects HTTP 200 with `{"status": "ok"}` response
+- Timeout: 30s (10s connect)
+
+### On failure
+
+- **Production**: Creates a GitHub issue labeled `downtime` with details. Subsequent failures add comments to the existing open issue (no duplicates).
+- **Preview**: Logs a warning in the workflow run (no issue created).
+
+## Setup
+
+### 1. Add repository secrets
+
+Go to **Settings → Secrets and variables → Actions** in the GitHub repo and add:
+
+| Secret            | Description                                | Example                        |
+| ----------------- | ------------------------------------------ | ------------------------------ |
+| `PRODUCTION_URL`  | Production instance base URL (no trailing `/`) | `https://app.paperclip.ing` |
+| `PREVIEW_URL`     | Preview/staging instance base URL (optional)   | `https://preview.paperclip.ing` |
+
+### 2. Create the `downtime` label
+
+Create a GitHub label named `downtime` (color suggestion: `#d73a4a`) so alerts are easy to filter.
+
+### 3. Verify
+
+Run the workflow manually: **Actions → Uptime Monitor → Run workflow**.
+
+## Responding to Alerts
+
+1. Check the GitHub issue for the HTTP status code and timestamp.
+2. Verify with: `curl -v https://<domain>/api/health`
+3. If the health endpoint returns `{"status": "degraded"}` (HTTP 503), the database is unreachable — check the Postgres container.
+4. Close the downtime issue once the service is restored.
+
+## SLA Tracking
+
+Uptime history is tracked via workflow run history in GitHub Actions. To calculate uptime percentage:
+
+- Each run is a 5-minute window
+- Successful runs = uptime, failed runs = downtime
+- Monthly uptime = (successful runs / total runs) × 100
+
+View history: **Actions → Uptime Monitor → filter by status**.


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/uptime-monitor.yml`) that checks `/api/health` every 5 minutes on production and preview
- On production downtime: auto-creates a GitHub issue labeled `downtime`; subsequent failures add comments to the existing issue (no duplicates)
- Preview failures are logged as warnings only (no issue created)
- Uses repository secrets (`PRODUCTION_URL`, `PREVIEW_URL`) for endpoint URLs
- Includes runbook (`doc/UPTIME-MONITORING.md`) with setup steps, alert response, and SLA tracking guidance

## Setup Required

After merge, add these repository secrets in **Settings → Secrets → Actions**:
- `PRODUCTION_URL` — e.g. `https://app.paperclip.ing`
- `PREVIEW_URL` — e.g. `https://preview.paperclip.ing` (optional)

Also create a `downtime` GitHub label for alert filtering.

## Test plan

- [ ] Verify workflow syntax with manual trigger (Actions → Uptime Monitor → Run workflow)
- [ ] Confirm health check passes with correct URL
- [ ] Simulate failure (bad URL) and verify issue creation
- [ ] Verify duplicate detection (second failure adds comment, not new issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)