### PR TITLE
feat: billing code spend endpoint + burn rate dashboard widget

### DIFF
--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -16,6 +16,8 @@ export interface DashboardSummary {
     monthSpendCents: number;
     monthBudgetCents: number;
     monthUtilizationPercent: number;
+    burnRateCentsPerDay: number;
+    projectedMonthEndSpendCents: number;
   };
   pendingApprovals: number;
   budgets: {

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -239,6 +239,14 @@ export function costRoutes(db: Db) {
     },
   );
 
+  router.get("/companies/:companyId/costs/by-billing-code", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const range = parseDateRange(req.query);
+    const rows = await costs.byBillingCode(companyId, range);
+    res.json(rows);
+  });
+
   router.get("/companies/:companyId/costs/by-project", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -311,6 +311,29 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .orderBy(costEvents.provider, costEvents.biller, costEvents.billingType, costEvents.model);
     },
 
+    byBillingCode: async (companyId: string, range?: CostDateRange) => {
+      const conditions: ReturnType<typeof eq>[] = [
+        eq(costEvents.companyId, companyId),
+        isNotNull(costEvents.billingCode),
+      ];
+      if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
+      if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
+
+      return db
+        .select({
+          billingCode: costEvents.billingCode,
+          costCents: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int`,
+          inputTokens: sql<number>`coalesce(sum(${costEvents.inputTokens}), 0)::int`,
+          cachedInputTokens: sql<number>`coalesce(sum(${costEvents.cachedInputTokens}), 0)::int`,
+          outputTokens: sql<number>`coalesce(sum(${costEvents.outputTokens}), 0)::int`,
+          eventCount: sql<number>`count(*)::int`,
+        })
+        .from(costEvents)
+        .where(and(...conditions))
+        .groupBy(costEvents.billingCode)
+        .orderBy(desc(sql`coalesce(sum(${costEvents.costCents}), 0)::int`));
+    },
+
     byProject: async (companyId: string, range?: CostDateRange) => {
       const issueIdAsText = sql<string>`${issues.id}::text`;
       const runProjectLinks = db

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -80,6 +80,13 @@ export function dashboardService(db: Db) {
         company.budgetMonthlyCents > 0
           ? (monthSpendCents / company.budgetMonthlyCents) * 100
           : 0;
+
+      // Burn rate: spend per day so far this month, projected to month end
+      const daysElapsed = Math.max(now.getDate(), 1);
+      const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+      const burnRateCentsPerDay = Math.round(monthSpendCents / daysElapsed);
+      const projectedMonthEndSpendCents = Math.round(burnRateCentsPerDay * daysInMonth);
+
       const budgetOverview = await budgets.overview(companyId);
 
       return {
@@ -95,6 +102,8 @@ export function dashboardService(db: Db) {
           monthSpendCents,
           monthBudgetCents: company.budgetMonthlyCents,
           monthUtilizationPercent: Number(utilization.toFixed(2)),
+          burnRateCentsPerDay,
+          projectedMonthEndSpendCents,
         },
         pendingApprovals,
         budgets: {

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -185,6 +185,8 @@ const dashboard: DashboardSummary = {
     monthSpendCents: 900,
     monthBudgetCents: 1000,
     monthUtilizationPercent: 90,
+    burnRateCentsPerDay: 45,
+    projectedMonthEndSpendCents: 1350,
   },
   pendingApprovals: 1,
   budgets: {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -265,6 +265,9 @@ export function Dashboard() {
                   {data.costs.monthBudgetCents > 0
                     ? `${data.costs.monthUtilizationPercent}% of ${formatCents(data.costs.monthBudgetCents)} budget`
                     : "Unlimited budget"}
+                  {data.costs.burnRateCentsPerDay > 0 && (
+                    <> · {formatCents(data.costs.burnRateCentsPerDay)}/day · proj. {formatCents(data.costs.projectedMonthEndSpendCents)}</>
+                  )}
                 </span>
               }
             />


### PR DESCRIPTION
## Summary

- **Spend by billing code**: New `GET /costs/by-billing-code` endpoint that aggregates `cost_events` by `billingCode`, matching the existing `by-agent`/`by-provider`/`by-project` pattern
- **Burn rate dashboard widget**: Dashboard summary now includes `burnRateCentsPerDay` and `projectedMonthEndSpendCents`, displayed inline in the Month Spend metric card

Closes the two remaining gaps identified in the PAP-27 budget enforcement audit plan. All other budget enforcement features (auto-pause, 80% warning, alerts, spend tracking) were already implemented upstream.

## Test plan

- [ ] Verify `GET /companies/:id/costs/by-billing-code` returns grouped spend when `billingCode` is set on cost events
- [ ] Verify dashboard summary includes `burnRateCentsPerDay` and `projectedMonthEndSpendCents`
- [ ] Confirm burn rate displays correctly in Dashboard Month Spend card when spend > 0
- [ ] Typecheck passes (pre-existing `plugin-host-services.ts` error unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)