### PR TITLE
fix: add heartbeat-monitoring to BOARD_ROUTE_ROOTS

### DIFF
--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -13,6 +13,7 @@ const BOARD_ROUTE_ROOTS = new Set([
   "activity",
   "inbox",
   "design-guide",
+  "heartbeat-monitoring",
 ]);
 
 const GLOBAL_ROUTE_ROOTS = new Set(["auth", "invite", "board-claim", "docs", "instance"]);


### PR DESCRIPTION
## Summary

- Adds `heartbeat-monitoring` to the `BOARD_ROUTE_ROOTS` set in `ui/src/lib/company-routes.ts`
- This fixes the heartbeats dashboard failing to load because the company prefix was not being applied to the URL

## Root Cause

The `applyCompanyPrefix()` function checks if a route's root segment is in `BOARD_ROUTE_ROOTS` to decide whether to prepend the company prefix. `heartbeat-monitoring` was missing from this set, so navigating to `/heartbeat-monitoring` instead of `/{PREFIX}/heartbeat-monitoring` caused a 404/error.

## Test plan

- [ ] Navigate to heartbeats dashboard in preview — should load correctly with company prefix in URL
- [ ] Verify other sidebar links still work

Fixes [PAP-31](/PAP/issues/PAP-31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)