### PR TITLE
feat: show git commit hash in version tooltip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
+RUN git rev-parse --short HEAD > .git-commit 2>/dev/null || echo "unknown" > .git-commit
 RUN pnpm --filter @paperclipai/plugin-sdk build
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/server build

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -3,7 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { and, count, eq, gt, isNull, sql } from "drizzle-orm";
 import { instanceUserRoles, invites } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
-import { serverVersion } from "../version.js";
+import { serverVersion, serverCommit } from "../version.js";
 import { Sentry, sentryEnabled } from "../sentry.js";
 
 const startedAt = Date.now();
@@ -31,6 +31,7 @@ export function healthRoutes(
       res.json({
         status: "ok",
         version: serverVersion,
+        commit: serverCommit,
         uptime: Math.floor((Date.now() - startedAt) / 1000),
       });
       return;
@@ -82,6 +83,7 @@ export function healthRoutes(
     res.status(healthy ? 200 : 503).json({
       status: healthy ? "ok" : "degraded",
       version: serverVersion,
+      commit: serverCommit,
       uptime: Math.floor((Date.now() - startedAt) / 1000),
       database: {
         status: dbStatus,

--- a/server/src/version.ts
+++ b/server/src/version.ts
@@ -1,4 +1,7 @@
 import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 type PackageJson = {
   version?: string;
@@ -8,3 +11,15 @@ const require = createRequire(import.meta.url);
 const pkg = require("../package.json") as PackageJson;
 
 export const serverVersion = pkg.version ?? "0.0.0";
+
+function readGitCommit(): string | null {
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const commitFile = resolve(__dirname, "../../.git-commit");
+    return readFileSync(commitFile, "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export const serverCommit = readGitCommit();

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -1,6 +1,7 @@
 export type HealthStatus = {
   status: "ok";
   version?: string;
+  commit?: string | null;
   deploymentMode?: "local_trusted" | "authenticated";
   deploymentExposure?: "private" | "public";
   authReady?: boolean;

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -303,7 +303,7 @@ export function Layout() {
                     <TooltipTrigger asChild>
                       <span className="px-2 text-xs text-muted-foreground shrink-0 cursor-default">v</span>
                     </TooltipTrigger>
-                    <TooltipContent>v{health.version}</TooltipContent>
+                    <TooltipContent>v{health.version}{health.commit ? ` (${health.commit})` : ""}</TooltipContent>
                   </Tooltip>
                 )}
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>
@@ -361,7 +361,7 @@ export function Layout() {
                     <TooltipTrigger asChild>
                       <span className="px-2 text-xs text-muted-foreground shrink-0 cursor-default">v</span>
                     </TooltipTrigger>
-                    <TooltipContent>v{health.version}</TooltipContent>
+                    <TooltipContent>v{health.version}{health.commit ? ` (${health.commit})` : ""}</TooltipContent>
                   </Tooltip>
                 )}
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground shrink-0" asChild>


### PR DESCRIPTION
## Summary

- Captures the short git commit hash at Docker build time (stored in `.git-commit`)
- Serves it via `/api/health` as `commit` field alongside `version`
- Displays it in the sidebar version tooltip as `v0.3.1 (abc1234)`
- Falls back gracefully to `null` when `.git-commit` is not available (dev mode)

Closes PAP-37

## Test plan

- [ ] Verify `/api/health` returns `commit` field in response
- [ ] Hover over "v" in sidebar to see version tooltip includes commit hash
- [ ] Docker build produces `.git-commit` file with correct short hash
- [ ] Dev mode works without `.git-commit` (commit shows as null, tooltip shows version only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)