### PR TITLE
fix: comments after= parameter causes 500 (Date in SQL)

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1192,16 +1192,23 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!anchor) return [];
+        const anchorTime = anchor.createdAt.toISOString();
         conditions.push(
           order === "asc"
-            ? sql<boolean>`(
-                ${issueComments.createdAt} > ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} > ${anchor.id})
-              )`
-            : sql<boolean>`(
-                ${issueComments.createdAt} < ${anchor.createdAt}
-                OR (${issueComments.createdAt} = ${anchor.createdAt} AND ${issueComments.id} < ${anchor.id})
-              )`,
+            ? or(
+                sql<boolean>`${issueComments.createdAt} > ${anchorTime}`,
+                and(
+                  sql<boolean>`${issueComments.createdAt} = ${anchorTime}`,
+                  sql<boolean>`${issueComments.id} > ${anchor.id}`,
+                ),
+              )!
+            : or(
+                sql<boolean>`${issueComments.createdAt} < ${anchorTime}`,
+                and(
+                  sql<boolean>`${issueComments.createdAt} = ${anchorTime}`,
+                  sql<boolean>`${issueComments.id} < ${anchor.id}`,
+                ),
+              )!,
         );
       }
 


### PR DESCRIPTION
## Summary
- Fix 500 error when using `after=` query parameter on `GET /issues/:id/comments`
- Root cause: JS Date object interpolated directly into SQL template literal
- Fix: Convert `anchor.createdAt` to ISO string before SQL interpolation

## Test plan
- [ ] Verify `GET /issues/:id/comments?after=<commentId>&order=asc` returns 200
- [ ] Verify `GET /issues/:id/comments?after=<commentId>&order=desc` returns 200
- [ ] Verify incremental comment loading works in agent heartbeats

Fixes PAP-32