### PR TITLE
fix: release on done issue leaves stale completedAt

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1126,6 +1126,9 @@ export function issueService(db: Db) {
           status: "todo",
           assigneeAgentId: null,
           checkoutRunId: null,
+          completedAt: null,
+          cancelledAt: null,
+          startedAt: null,
           updatedAt: new Date(),
         })
         .where(eq(issues.id, id))


### PR DESCRIPTION
## Summary
- Clear `completedAt`, `cancelledAt`, and `startedAt` when releasing an issue back to `todo`
- Prevents inconsistent state where a released issue has timestamps from its prior lifecycle

## Test plan
- [ ] Release a `done` issue → verify `completedAt` is null
- [ ] Release a `cancelled` issue → verify `cancelledAt` is null
- [ ] Release an `in_progress` issue → verify `startedAt` is null

Fixes PAP-34