### PR TITLE
fix: add limit/offset pagination to issues list and activity log

### DIFF
--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -33,11 +33,15 @@ export function activityRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
 
+    const limitRaw = req.query.limit as string | undefined;
+    const offsetRaw = req.query.offset as string | undefined;
     const filters = {
       companyId,
       agentId: req.query.agentId as string | undefined,
       entityType: req.query.entityType as string | undefined,
       entityId: req.query.entityId as string | undefined,
+      limit: limitRaw ? parseInt(limitRaw, 10) : undefined,
+      offset: offsetRaw ? parseInt(offsetRaw, 10) : undefined,
     };
     const result = await svc.list(filters);
     res.json(result);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -227,6 +227,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
       return;
     }
 
+    const limitRaw = req.query.limit as string | undefined;
+    const offsetRaw = req.query.offset as string | undefined;
     const result = await svc.list(companyId, {
       status: req.query.status as string | undefined,
       assigneeAgentId: req.query.assigneeAgentId as string | undefined,
@@ -237,6 +239,8 @@ export function issueRoutes(db: Db, storage: StorageService) {
       parentId: req.query.parentId as string | undefined,
       labelId: req.query.labelId as string | undefined,
       q: req.query.q as string | undefined,
+      limit: limitRaw ? parseInt(limitRaw, 10) : undefined,
+      offset: offsetRaw ? parseInt(offsetRaw, 10) : undefined,
     });
     res.json(result);
   });

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -7,6 +7,8 @@ export interface ActivityFilters {
   agentId?: string;
   entityType?: string;
   entityId?: string;
+  limit?: number;
+  offset?: number;
 }
 
 export function activityService(db: Db) {
@@ -25,6 +27,8 @@ export function activityService(db: Db) {
         conditions.push(eq(activityLog.entityId, filters.entityId));
       }
 
+      const pageLimit = Math.min(Math.max(filters.limit ?? 50, 1), 200);
+      const pageOffset = Math.max(filters.offset ?? 0, 0);
       return db
         .select({ activityLog })
         .from(activityLog)
@@ -45,6 +49,8 @@ export function activityService(db: Db) {
           ),
         )
         .orderBy(desc(activityLog.createdAt))
+        .limit(pageLimit)
+        .offset(pageOffset)
         .then((rows) => rows.map((r) => r.activityLog));
     },
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -69,6 +69,8 @@ export interface IssueFilters {
   parentId?: string;
   labelId?: string;
   q?: string;
+  limit?: number;
+  offset?: number;
 }
 
 type IssueRow = typeof issues.$inferSelect;
@@ -548,11 +550,15 @@ export function issueService(db: Db) {
           ELSE 6
         END
       `;
+      const pageLimit = Math.min(Math.max(filters?.limit ?? 50, 1), 200);
+      const pageOffset = Math.max(filters?.offset ?? 0, 0);
       const rows = await db
         .select()
         .from(issues)
         .where(and(...conditions))
-        .orderBy(hasSearch ? asc(searchOrder) : asc(priorityOrder), asc(priorityOrder), desc(issues.updatedAt));
+        .orderBy(hasSearch ? asc(searchOrder) : asc(priorityOrder), asc(priorityOrder), desc(issues.updatedAt))
+        .limit(pageLimit)
+        .offset(pageOffset);
       const withLabels = await withIssueLabels(db, rows);
       const runMap = await activeRunMapForIssues(db, withLabels);
       const withRuns = withActiveRuns(withLabels, runMap);


### PR DESCRIPTION
## Summary
- Add `limit` and `offset` query params to `GET /companies/:id/issues` and `GET /companies/:id/activity`
- Default limit: 50, max: 200, offset >= 0
- Previously both endpoints returned all rows with no pagination

## Test plan
- [ ] `GET /companies/:id/issues?limit=10` returns max 10 issues
- [ ] `GET /companies/:id/issues?limit=10&offset=10` returns next page
- [ ] `GET /companies/:id/activity?limit=5` returns max 5 entries
- [ ] Default behavior (no params) returns up to 50 items

Fixes PAP-33