### PR TITLE
fix: add max length validation to issue title

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -32,7 +32,7 @@ export const createIssueSchema = z.object({
   projectWorkspaceId: z.string().uuid().optional().nullable(),
   goalId: z.string().uuid().optional().nullable(),
   parentId: z.string().uuid().optional().nullable(),
-  title: z.string().min(1),
+  title: z.string().min(1).max(200),
   description: z.string().optional().nullable(),
   status: z.enum(ISSUE_STATUSES).optional().default("backlog"),
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),


### PR DESCRIPTION
## Summary
- Add `.max(200)` to issue title Zod schema
- Both create and update paths are covered (update inherits from create schema)

## Test plan
- [ ] Create issue with 201+ char title → 422 validation error
- [ ] Create issue with 200 char title → succeeds
- [ ] Update issue title to 201+ chars → 422

Fixes PAP-36