### PR TITLE
fix: reject release on done/cancelled issues

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1166,6 +1166,15 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!existing) return null;
+
+      // Reject release on terminal-status issues
+      if (existing.status === "done" || existing.status === "cancelled") {
+        throw conflict(`Cannot release issue in '${existing.status}' status`, {
+          issueId: existing.id,
+          status: existing.status,
+        });
+      }
+
       if (actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
         throw conflict("Only assignee can release issue");
       }


### PR DESCRIPTION
## Summary

- Adds a guard in release() (server/src/services/issues.ts) that throws a 409 Conflict when release is called on issues with terminal status (done or cancelled)
- Prevents silent reversion of completed work where completedAt would remain stale while status reverts to todo
- Existing guards for assignee and checkout-run ownership are preserved

## Test plan

- [ ] Call POST /api/issues/:id/release on a done issue — expect 409
- [ ] Call POST /api/issues/:id/release on a cancelled issue — expect 409
- [ ] Call POST /api/issues/:id/release on an in_progress issue — expect normal release to todo
- [ ] Typecheck passes (pnpm -r typecheck)

Closes PAP-48