### PR TITLE
feat: scaffold and implement paperclip-plugin-obsidian (MVP)

### DIFF
--- a/packages/plugins/plugin-obsidian/package.json
+++ b/packages/plugins/plugin-obsidian/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@paperclipai/plugin-obsidian",
+  "version": "0.1.0",
+  "description": "Unidirectional sync from Paperclip to an Obsidian vault — exports issues and goals as Markdown notes with YAML frontmatter and wikilinks",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc && node ./scripts/build-ui.mjs",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@paperclipai/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "esbuild": "^0.27.3",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.1"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/plugin-obsidian/scripts/build-ui.mjs
+++ b/packages/plugins/plugin-obsidian/scripts/build-ui.mjs
@@ -1,0 +1,24 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@paperclipai/plugin-sdk/ui",
+  ],
+  logLevel: "info",
+});

--- a/packages/plugins/plugin-obsidian/src/constants.ts
+++ b/packages/plugins/plugin-obsidian/src/constants.ts
@@ -1,0 +1,54 @@
+export const PLUGIN_ID = "paperclip-plugin-obsidian";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const SLOT_IDS = {
+  settingsPage: "obsidian-settings-page",
+  dashboardWidget: "obsidian-dashboard-widget",
+} as const;
+
+export const EXPORT_NAMES = {
+  settingsPage: "ObsidianSettingsPage",
+  dashboardWidget: "ObsidianDashboardWidget",
+} as const;
+
+export const JOB_KEYS = {
+  sync: "obsidian-sync",
+} as const;
+
+export const DATA_KEYS = {
+  syncHealth: "sync-health",
+  syncLog: "sync-log",
+} as const;
+
+export const ACTION_KEYS = {
+  triggerSync: "trigger-sync",
+} as const;
+
+export const STATE_KEYS = {
+  lastSyncCursor: "last-sync-cursor",
+  syncConfig: "sync-config",
+} as const;
+
+export type SyncEntityType = "issues" | "goals";
+
+export interface ObsidianPluginConfig {
+  vaultPath: string;
+  gitRemoteUrl: string;
+  gitBranch: string;
+  syncEntities: SyncEntityType[];
+  syncIntervalMinutes: number;
+  folderStructure: "by-project" | "flat";
+  includeComments: boolean;
+  maxCommentsPerIssue: number;
+}
+
+export const DEFAULT_CONFIG: ObsidianPluginConfig = {
+  vaultPath: "",
+  gitRemoteUrl: "",
+  gitBranch: "main",
+  syncEntities: ["issues", "goals"],
+  syncIntervalMinutes: 15,
+  folderStructure: "by-project",
+  includeComments: true,
+  maxCommentsPerIssue: 10,
+};

--- a/packages/plugins/plugin-obsidian/src/index.ts
+++ b/packages/plugins/plugin-obsidian/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/plugin-obsidian/src/lib/git-sync.ts
+++ b/packages/plugins/plugin-obsidian/src/lib/git-sync.ts
@@ -1,0 +1,147 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+interface GitExecResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+async function gitExec(args: string[], cwd: string): Promise<GitExecResult> {
+  return new Promise((resolve) => {
+    const proc = spawn("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d: Buffer) => {
+      stdout += d.toString();
+    });
+    proc.stderr.on("data", (d: Buffer) => {
+      stderr += d.toString();
+    });
+    proc.on("close", (code) => {
+      resolve({ code, stdout: stdout.trim(), stderr: stderr.trim() });
+    });
+    proc.on("error", (err) => {
+      resolve({ code: 1, stdout: "", stderr: err.message });
+    });
+  });
+}
+
+/**
+ * Ensure the vault directory exists and is a git repo.
+ * If gitRemoteUrl is provided and the directory doesn't exist, clone it.
+ * If it exists, pull latest changes.
+ */
+export async function ensureRepo(opts: {
+  vaultPath: string;
+  gitRemoteUrl: string;
+  gitBranch: string;
+}): Promise<{ cloned: boolean; pulled: boolean; error?: string }> {
+  const { vaultPath, gitRemoteUrl, gitBranch } = opts;
+
+  // Check if directory exists
+  let dirExists = false;
+  try {
+    const stat = await fs.stat(vaultPath);
+    dirExists = stat.isDirectory();
+  } catch {
+    dirExists = false;
+  }
+
+  if (!dirExists && gitRemoteUrl) {
+    // Clone the repo
+    const parentDir = path.dirname(vaultPath);
+    const dirName = path.basename(vaultPath);
+    await fs.mkdir(parentDir, { recursive: true });
+    const result = await gitExec(
+      ["clone", "--branch", gitBranch, "--single-branch", gitRemoteUrl, dirName],
+      parentDir,
+    );
+    if (result.code !== 0) {
+      return { cloned: false, pulled: false, error: `git clone failed: ${result.stderr}` };
+    }
+    return { cloned: true, pulled: false };
+  }
+
+  if (!dirExists) {
+    // No remote URL and directory doesn't exist — create it
+    await fs.mkdir(vaultPath, { recursive: true });
+    await gitExec(["init"], vaultPath);
+    return { cloned: false, pulled: false };
+  }
+
+  // Directory exists — check if it's a git repo
+  const isGitRepo = await gitExec(["rev-parse", "--git-dir"], vaultPath);
+  if (isGitRepo.code !== 0) {
+    // Not a git repo, just use as-is for local vaults
+    return { cloned: false, pulled: false };
+  }
+
+  if (gitRemoteUrl) {
+    // Pull latest
+    const pullResult = await gitExec(["pull", "--rebase", "origin", gitBranch], vaultPath);
+    if (pullResult.code !== 0) {
+      return {
+        cloned: false,
+        pulled: false,
+        error: `git pull failed: ${pullResult.stderr}`,
+      };
+    }
+    return { cloned: false, pulled: true };
+  }
+
+  return { cloned: false, pulled: false };
+}
+
+/**
+ * Stage all changes, commit, and push to the remote.
+ */
+export async function commitAndPush(opts: {
+  vaultPath: string;
+  gitRemoteUrl: string;
+  gitBranch: string;
+  message: string;
+}): Promise<{ committed: boolean; pushed: boolean; error?: string }> {
+  const { vaultPath, gitRemoteUrl, gitBranch, message } = opts;
+
+  // Stage all changes
+  const addResult = await gitExec(["add", "-A"], vaultPath);
+  if (addResult.code !== 0) {
+    return { committed: false, pushed: false, error: `git add failed: ${addResult.stderr}` };
+  }
+
+  // Check if there's anything to commit
+  const statusResult = await gitExec(["status", "--porcelain"], vaultPath);
+  if (!statusResult.stdout) {
+    return { committed: false, pushed: false };
+  }
+
+  // Commit
+  const commitResult = await gitExec(
+    ["commit", "-m", message, "--author", "Paperclip Obsidian Sync <noreply@paperclip.ing>"],
+    vaultPath,
+  );
+  if (commitResult.code !== 0) {
+    return {
+      committed: false,
+      pushed: false,
+      error: `git commit failed: ${commitResult.stderr}`,
+    };
+  }
+
+  // Push if remote is configured
+  if (gitRemoteUrl) {
+    const pushResult = await gitExec(["push", "origin", gitBranch], vaultPath);
+    if (pushResult.code !== 0) {
+      return {
+        committed: true,
+        pushed: false,
+        error: `git push failed: ${pushResult.stderr}`,
+      };
+    }
+    return { committed: true, pushed: true };
+  }
+
+  return { committed: true, pushed: false };
+}

--- a/packages/plugins/plugin-obsidian/src/lib/mapper.ts
+++ b/packages/plugins/plugin-obsidian/src/lib/mapper.ts
@@ -1,0 +1,146 @@
+import type { Goal, Issue } from "@paperclipai/shared";
+
+/**
+ * Represents a single Obsidian note to be written to the vault.
+ */
+export interface ObsidianNote {
+  /** Relative path within the vault (e.g. "Projects/Website/Issues/PAP-42.md") */
+  relativePath: string;
+  /** YAML frontmatter fields */
+  frontmatter: Record<string, unknown>;
+  /** Markdown body content */
+  body: string;
+}
+
+export interface MapperContext {
+  /** Map of project IDs to project names */
+  projectNames: Map<string, string>;
+  /** Map of agent IDs to agent names */
+  agentNames: Map<string, string>;
+  /** Map of goal IDs to goal titles */
+  goalTitles: Map<string, string>;
+  /** Comments keyed by issue ID */
+  commentsByIssue: Map<string, Array<{ body: string; createdAt: string; authorName: string }>>;
+  /** Folder structure preference */
+  folderStructure: "by-project" | "flat";
+  /** Whether to include comments */
+  includeComments: boolean;
+  /** Max comments per issue */
+  maxCommentsPerIssue: number;
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_").trim();
+}
+
+function issueFolder(issue: Issue, ctx: MapperContext): string {
+  if (ctx.folderStructure === "flat") return "Issues";
+  const projectName = issue.projectId
+    ? ctx.projectNames.get(issue.projectId) ?? "Uncategorized"
+    : "Uncategorized";
+  return `Projects/${sanitizeFilename(projectName)}/Issues`;
+}
+
+function goalFolder(goal: Goal, ctx: MapperContext): string {
+  if (ctx.folderStructure === "flat") return "Goals";
+  return "Goals";
+}
+
+function formatDate(d: Date | string | null | undefined): string {
+  if (!d) return "";
+  const date = typeof d === "string" ? new Date(d) : d;
+  return date.toISOString().split("T")[0];
+}
+
+function buildWikilinks(text: string): string {
+  // Convert PAP-123 style references to [[PAP-123]] wikilinks
+  return text.replace(/\b([A-Z]+-\d+)\b/g, "[[$1]]");
+}
+
+export function mapIssueToNote(issue: Issue, ctx: MapperContext): ObsidianNote {
+  const identifier = issue.identifier ?? `issue-${issue.id.slice(0, 8)}`;
+  const filename = sanitizeFilename(identifier);
+  const folder = issueFolder(issue, ctx);
+  const relativePath = `${folder}/${filename}.md`;
+
+  const assignee = issue.assigneeAgentId
+    ? ctx.agentNames.get(issue.assigneeAgentId) ?? null
+    : null;
+  const project = issue.projectId
+    ? ctx.projectNames.get(issue.projectId) ?? null
+    : null;
+  const goalTitle = issue.goalId
+    ? ctx.goalTitles.get(issue.goalId) ?? null
+    : null;
+
+  const frontmatter: Record<string, unknown> = {
+    paperclip_id: issue.id,
+    identifier,
+    status: issue.status,
+    priority: issue.priority,
+    assignee,
+    project,
+    goal: goalTitle,
+    parent: issue.parentId ?? null,
+    created: formatDate(issue.createdAt),
+    updated: formatDate(issue.updatedAt),
+    tags: ["paperclip", "issue"],
+  };
+
+  let body = `# ${issue.title}\n\n`;
+
+  if (issue.description) {
+    body += buildWikilinks(issue.description) + "\n\n";
+  }
+
+  if (ctx.includeComments) {
+    const comments = ctx.commentsByIssue.get(issue.id) ?? [];
+    const recent = comments.slice(-ctx.maxCommentsPerIssue);
+    if (recent.length > 0) {
+      body += "## Comments\n\n";
+      for (const c of recent) {
+        const date = formatDate(c.createdAt);
+        const author = c.authorName || "Unknown";
+        body += `### ${author} — ${date}\n\n`;
+        body += buildWikilinks(c.body) + "\n\n";
+      }
+    }
+  }
+
+  // Add related issue wikilinks
+  if (issue.parentId) {
+    const parentIdentifier = issue.parentId; // Will be resolved to identifier if available
+    body += `---\nParent: [[${parentIdentifier}]]\n`;
+  }
+
+  return { relativePath, frontmatter, body };
+}
+
+export function mapGoalToNote(goal: Goal, ctx: MapperContext): ObsidianNote {
+  const filename = sanitizeFilename(goal.title || `goal-${goal.id.slice(0, 8)}`);
+  const folder = goalFolder(goal, ctx);
+  const relativePath = `${folder}/${filename}.md`;
+
+  const owner = goal.ownerAgentId
+    ? ctx.agentNames.get(goal.ownerAgentId) ?? null
+    : null;
+
+  const frontmatter: Record<string, unknown> = {
+    paperclip_id: goal.id,
+    level: goal.level,
+    status: goal.status,
+    owner,
+    parent_goal: goal.parentId ?? null,
+    created: formatDate(goal.createdAt),
+    updated: formatDate(goal.updatedAt),
+    tags: ["paperclip", "goal"],
+  };
+
+  let body = `# ${goal.title}\n\n`;
+
+  if (goal.description) {
+    body += buildWikilinks(goal.description) + "\n\n";
+  }
+
+  return { relativePath, frontmatter, body };
+}

--- a/packages/plugins/plugin-obsidian/src/lib/vault-writer.ts
+++ b/packages/plugins/plugin-obsidian/src/lib/vault-writer.ts
@@ -1,0 +1,65 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { ObsidianNote } from "./mapper.js";
+
+/**
+ * Serialize a frontmatter object to YAML format.
+ */
+function serializeFrontmatter(fm: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(fm)) {
+    if (value === null || value === undefined) {
+      lines.push(`${key}: null`);
+    } else if (Array.isArray(value)) {
+      if (value.length === 0) {
+        lines.push(`${key}: []`);
+      } else {
+        lines.push(`${key}:`);
+        for (const item of value) {
+          lines.push(`  - ${JSON.stringify(item)}`);
+        }
+      }
+    } else if (typeof value === "string") {
+      // Quote strings that contain special YAML characters
+      if (/[:#{}[\],&*?|>!%@`]/.test(value) || value.includes("\n")) {
+        lines.push(`${key}: ${JSON.stringify(value)}`);
+      } else {
+        lines.push(`${key}: ${value}`);
+      }
+    } else {
+      lines.push(`${key}: ${JSON.stringify(value)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Render a complete Obsidian note with YAML frontmatter and markdown body.
+ */
+export function renderNote(note: ObsidianNote): string {
+  const fm = serializeFrontmatter(note.frontmatter);
+  return `---\n${fm}\n---\n\n${note.body}`;
+}
+
+/**
+ * Write notes to the filesystem vault directory.
+ * Creates directories as needed.
+ * Returns the list of file paths written.
+ */
+export async function writeNotesToVault(
+  vaultPath: string,
+  notes: ObsidianNote[],
+): Promise<string[]> {
+  const written: string[] = [];
+
+  for (const note of notes) {
+    const fullPath = path.join(vaultPath, note.relativePath);
+    const dir = path.dirname(fullPath);
+    await fs.mkdir(dir, { recursive: true });
+    const content = renderNote(note);
+    await fs.writeFile(fullPath, content, "utf-8");
+    written.push(fullPath);
+  }
+
+  return written;
+}

--- a/packages/plugins/plugin-obsidian/src/manifest.ts
+++ b/packages/plugins/plugin-obsidian/src/manifest.ts
@@ -1,0 +1,129 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import {
+  DEFAULT_CONFIG,
+  EXPORT_NAMES,
+  JOB_KEYS,
+  PLUGIN_ID,
+  PLUGIN_VERSION,
+  SLOT_IDS,
+} from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Obsidian Vault Sync",
+  description:
+    "Unidirectional sync from Paperclip to an Obsidian vault. Exports issues and goals as Markdown notes with YAML frontmatter and wikilinks.",
+  author: "Paperclip",
+  categories: ["connector"],
+  capabilities: [
+    "companies.read",
+    "projects.read",
+    "issues.read",
+    "issue.comments.read",
+    "goals.read",
+    "agents.read",
+    "events.subscribe",
+    "jobs.schedule",
+    "plugin.state.read",
+    "plugin.state.write",
+    "http.outbound",
+    "instance.settings.register",
+    "ui.dashboardWidget.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      vaultPath: {
+        type: "string",
+        title: "Vault Path",
+        description:
+          "Absolute path to the local Obsidian vault directory. Leave empty if using a git remote.",
+        default: DEFAULT_CONFIG.vaultPath,
+      },
+      gitRemoteUrl: {
+        type: "string",
+        title: "Git Remote URL",
+        description:
+          "Git remote URL for the vault repository (e.g. https://github.com/user/vault.git). Leave empty for local-only vaults.",
+        default: DEFAULT_CONFIG.gitRemoteUrl,
+      },
+      gitBranch: {
+        type: "string",
+        title: "Git Branch",
+        description: "Branch to sync to in the git remote.",
+        default: DEFAULT_CONFIG.gitBranch,
+      },
+      syncEntities: {
+        type: "array",
+        title: "Entities to Sync",
+        description: "Which Paperclip entities to export as Obsidian notes.",
+        items: {
+          type: "string",
+          enum: ["issues", "goals"],
+        },
+        default: DEFAULT_CONFIG.syncEntities,
+      },
+      syncIntervalMinutes: {
+        type: "number",
+        title: "Sync Interval (minutes)",
+        description: "How often to run the sync job.",
+        default: DEFAULT_CONFIG.syncIntervalMinutes,
+      },
+      folderStructure: {
+        type: "string",
+        title: "Folder Structure",
+        description:
+          "How to organize notes: by-project groups notes under project folders, flat puts everything at the top level.",
+        enum: ["by-project", "flat"],
+        default: DEFAULT_CONFIG.folderStructure,
+      },
+      includeComments: {
+        type: "boolean",
+        title: "Include Comments",
+        description: "Whether to include issue comments in the exported notes.",
+        default: DEFAULT_CONFIG.includeComments,
+      },
+      maxCommentsPerIssue: {
+        type: "number",
+        title: "Max Comments per Issue",
+        description:
+          "Maximum number of comments to include per issue note (most recent first).",
+        default: DEFAULT_CONFIG.maxCommentsPerIssue,
+      },
+    },
+    required: [],
+  },
+  jobs: [
+    {
+      jobKey: JOB_KEYS.sync,
+      displayName: "Obsidian Vault Sync",
+      description:
+        "Exports changed Paperclip issues and goals as Markdown notes to the configured Obsidian vault.",
+      schedule: "*/15 * * * *",
+    },
+  ],
+  ui: {
+    slots: [
+      {
+        type: "settingsPage",
+        id: SLOT_IDS.settingsPage,
+        displayName: "Obsidian Sync Settings",
+        exportName: EXPORT_NAMES.settingsPage,
+      },
+      {
+        type: "dashboardWidget",
+        id: SLOT_IDS.dashboardWidget,
+        displayName: "Obsidian Sync",
+        exportName: EXPORT_NAMES.dashboardWidget,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/plugin-obsidian/src/ui/index.tsx
+++ b/packages/plugins/plugin-obsidian/src/ui/index.tsx
@@ -1,0 +1,281 @@
+import {
+  usePluginAction,
+  usePluginData,
+  usePluginToast,
+  type PluginWidgetProps,
+} from "@paperclipai/plugin-sdk/ui";
+import React, { useCallback, useState } from "react";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+interface SyncHealth {
+  status: "configured" | "unconfigured";
+  lastSync: {
+    lastSyncAt: string;
+    issueCount: number;
+    goalCount: number;
+  } | null;
+  vaultPath: string;
+  gitRemoteUrl: string | null;
+  syncEntities: string[];
+}
+
+interface SyncResult {
+  success: boolean;
+  issuesSynced: number;
+  goalsSynced: number;
+  filesWritten: number;
+  gitCommitted: boolean;
+  gitPushed: boolean;
+  error?: string;
+  syncedAt: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Shared styles                                                      */
+/* ------------------------------------------------------------------ */
+
+const styles = {
+  container: {
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    fontSize: "13px",
+    lineHeight: "1.5",
+    color: "#e0e0e0",
+  } as React.CSSProperties,
+  card: {
+    background: "#1e1e2e",
+    borderRadius: "8px",
+    padding: "16px",
+    border: "1px solid #333",
+  } as React.CSSProperties,
+  heading: {
+    margin: "0 0 12px 0",
+    fontSize: "15px",
+    fontWeight: 600,
+    color: "#fff",
+  } as React.CSSProperties,
+  label: {
+    display: "block",
+    fontSize: "12px",
+    color: "#888",
+    marginBottom: "2px",
+  } as React.CSSProperties,
+  value: {
+    fontSize: "13px",
+    color: "#ccc",
+  } as React.CSSProperties,
+  button: {
+    background: "#4c6ef5",
+    color: "#fff",
+    border: "none",
+    borderRadius: "6px",
+    padding: "6px 14px",
+    fontSize: "12px",
+    cursor: "pointer",
+  } as React.CSSProperties,
+  buttonDisabled: {
+    background: "#555",
+    cursor: "not-allowed",
+  } as React.CSSProperties,
+  badge: (color: string) =>
+    ({
+      display: "inline-block",
+      fontSize: "11px",
+      padding: "2px 8px",
+      borderRadius: "4px",
+      background: color,
+      color: "#fff",
+    }) as React.CSSProperties,
+  row: {
+    display: "flex",
+    gap: "12px",
+    flexWrap: "wrap",
+    marginBottom: "8px",
+  } as React.CSSProperties,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Dashboard Widget                                                   */
+/* ------------------------------------------------------------------ */
+
+export function ObsidianDashboardWidget({ context }: PluginWidgetProps) {
+  const { data, loading, error, refresh } = usePluginData<SyncHealth>(
+    "sync-health",
+    { companyId: context.companyId },
+  );
+  const triggerSync = usePluginAction("trigger-sync");
+  const toast = usePluginToast();
+  const [syncing, setSyncing] = useState(false);
+
+  const handleSync = useCallback(async () => {
+    setSyncing(true);
+    try {
+      const result = (await triggerSync({
+        companyId: context.companyId,
+      })) as SyncResult;
+      if (result.success) {
+        toast({
+          title: `Synced ${result.issuesSynced} issues, ${result.goalsSynced} goals`,
+        });
+      } else {
+        toast({ title: `Sync failed: ${result.error}`, tone: "error" });
+      }
+      refresh();
+    } catch (err) {
+      toast({ title: "Sync failed", tone: "error" });
+    } finally {
+      setSyncing(false);
+    }
+  }, [triggerSync, context.companyId, toast, refresh]);
+
+  if (loading) {
+    return (
+      <div style={styles.container}>
+        <div style={styles.card}>Loading sync status...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={styles.container}>
+        <div style={styles.card}>Error: {error.message}</div>
+      </div>
+    );
+  }
+
+  const statusColor =
+    data?.status === "configured" ? "#2ea043" : "#888";
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.card}>
+        <h3 style={styles.heading}>Obsidian Vault Sync</h3>
+
+        <div style={styles.row}>
+          <span style={styles.badge(statusColor)}>
+            {data?.status ?? "unknown"}
+          </span>
+          {data?.syncEntities?.map((e) => (
+            <span key={e} style={styles.badge("#4c6ef5")}>
+              {e}
+            </span>
+          ))}
+        </div>
+
+        {data?.lastSync ? (
+          <div style={{ marginBottom: "8px" }}>
+            <span style={styles.label}>Last sync</span>
+            <span style={styles.value}>
+              {new Date(data.lastSync.lastSyncAt).toLocaleString()} —{" "}
+              {data.lastSync.issueCount} issues, {data.lastSync.goalCount}{" "}
+              goals
+            </span>
+          </div>
+        ) : (
+          <div style={{ marginBottom: "8px", color: "#888" }}>
+            No sync recorded yet.
+          </div>
+        )}
+
+        {data?.vaultPath && (
+          <div style={{ marginBottom: "8px" }}>
+            <span style={styles.label}>Vault</span>
+            <span style={styles.value}>{data.vaultPath}</span>
+          </div>
+        )}
+
+        <button
+          style={{
+            ...styles.button,
+            ...(syncing ? styles.buttonDisabled : {}),
+          }}
+          disabled={syncing || data?.status !== "configured"}
+          onClick={handleSync}
+        >
+          {syncing ? "Syncing..." : "Sync Now"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Settings Page                                                      */
+/* ------------------------------------------------------------------ */
+
+export function ObsidianSettingsPage({ context }: PluginWidgetProps) {
+  const { data, loading, refresh } = usePluginData<SyncHealth>("sync-health", {
+    companyId: context.companyId,
+  });
+
+  if (loading) {
+    return (
+      <div style={styles.container}>
+        <div style={styles.card}>Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.card}>
+        <h3 style={styles.heading}>Obsidian Vault Sync — Settings</h3>
+        <p style={{ color: "#aaa", margin: "0 0 16px 0" }}>
+          Configure vault path and sync options using the instance config form
+          above. This page shows the current sync status.
+        </p>
+
+        <div style={{ marginBottom: "12px" }}>
+          <span style={styles.label}>Status</span>
+          <span
+            style={styles.badge(
+              data?.status === "configured" ? "#2ea043" : "#888",
+            )}
+          >
+            {data?.status ?? "unknown"}
+          </span>
+        </div>
+
+        {data?.vaultPath && (
+          <div style={{ marginBottom: "12px" }}>
+            <span style={styles.label}>Vault Path</span>
+            <span style={styles.value}>{data.vaultPath}</span>
+          </div>
+        )}
+
+        {data?.gitRemoteUrl && (
+          <div style={{ marginBottom: "12px" }}>
+            <span style={styles.label}>Git Remote</span>
+            <span style={styles.value}>{data.gitRemoteUrl}</span>
+          </div>
+        )}
+
+        {data?.lastSync && (
+          <div style={{ marginBottom: "12px" }}>
+            <span style={styles.label}>Last Sync</span>
+            <span style={styles.value}>
+              {new Date(data.lastSync.lastSyncAt).toLocaleString()} —{" "}
+              {data.lastSync.issueCount} issues, {data.lastSync.goalCount}{" "}
+              goals
+            </span>
+          </div>
+        )}
+
+        <div style={{ marginBottom: "12px" }}>
+          <span style={styles.label}>Sync Entities</span>
+          <div style={styles.row}>
+            {data?.syncEntities?.map((e) => (
+              <span key={e} style={styles.badge("#4c6ef5")}>
+                {e}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/plugins/plugin-obsidian/src/worker.ts
+++ b/packages/plugins/plugin-obsidian/src/worker.ts
@@ -1,0 +1,401 @@
+import {
+  definePlugin,
+  runWorker,
+  type PluginContext,
+  type PluginJobContext,
+} from "@paperclipai/plugin-sdk";
+import type { Goal, Issue } from "@paperclipai/shared";
+import {
+  ACTION_KEYS,
+  DATA_KEYS,
+  DEFAULT_CONFIG,
+  JOB_KEYS,
+  STATE_KEYS,
+  type ObsidianPluginConfig,
+  type SyncEntityType,
+} from "./constants.js";
+import { commitAndPush, ensureRepo } from "./lib/git-sync.js";
+import {
+  mapGoalToNote,
+  mapIssueToNote,
+  type MapperContext,
+  type ObsidianNote,
+} from "./lib/mapper.js";
+import { writeNotesToVault } from "./lib/vault-writer.js";
+
+interface SyncCursor {
+  lastSyncAt: string;
+  issueCount: number;
+  goalCount: number;
+}
+
+interface SyncResult {
+  success: boolean;
+  issuesSynced: number;
+  goalsSynced: number;
+  filesWritten: number;
+  gitCommitted: boolean;
+  gitPushed: boolean;
+  error?: string;
+  syncedAt: string;
+}
+
+async function getConfig(ctx: PluginContext): Promise<ObsidianPluginConfig> {
+  const raw = (await ctx.config.get()) as Partial<ObsidianPluginConfig>;
+  return { ...DEFAULT_CONFIG, ...raw };
+}
+
+async function getVaultPath(config: ObsidianPluginConfig): Promise<string> {
+  if (config.vaultPath) return config.vaultPath;
+  if (config.gitRemoteUrl) {
+    // Derive vault path from git URL
+    const repoName = config.gitRemoteUrl
+      .split("/")
+      .pop()
+      ?.replace(/\.git$/, "") ?? "obsidian-vault";
+    return `/tmp/paperclip-obsidian-vaults/${repoName}`;
+  }
+  throw new Error("Either vaultPath or gitRemoteUrl must be configured");
+}
+
+async function buildMapperContext(
+  ctx: PluginContext,
+  config: ObsidianPluginConfig,
+  companyId: string,
+  issues: Issue[],
+): Promise<MapperContext> {
+  // Collect goal IDs to resolve titles
+  const goalIds = new Set<string>();
+  for (const issue of issues) {
+    if (issue.goalId) goalIds.add(issue.goalId);
+  }
+
+  // Resolve names in parallel
+  const projectNames = new Map<string, string>();
+  const agentNames = new Map<string, string>();
+  const goalTitles = new Map<string, string>();
+  const commentsByIssue = new Map<string, Array<{ body: string; createdAt: string; authorName: string }>>();
+
+  const [projects, agents] = await Promise.all([
+    ctx.projects.list({ companyId }),
+    ctx.agents.list({ companyId }),
+  ]);
+
+  for (const p of projects) {
+    projectNames.set(p.id, p.name);
+  }
+  for (const a of agents) {
+    agentNames.set(a.id, a.name);
+  }
+
+  // Fetch goals for title resolution
+  if (goalIds.size > 0) {
+    const goals = await ctx.goals.list({ companyId });
+    for (const g of goals) {
+      goalTitles.set(g.id, g.title);
+    }
+  }
+
+  // Fetch comments if configured
+  if (config.includeComments) {
+    // Fetch in batches to avoid overwhelming the API
+    for (const issue of issues) {
+      try {
+        const comments = await ctx.issues.listComments(issue.id, issue.companyId);
+        commentsByIssue.set(
+          issue.id,
+          comments.map((c: { body?: string; createdAt: Date | string; authorAgentId?: string | null }) => ({
+            body: c.body ?? "",
+            createdAt: typeof c.createdAt === "string" ? c.createdAt : new Date(c.createdAt).toISOString(),
+            authorName: c.authorAgentId
+              ? agentNames.get(c.authorAgentId) ?? "Agent"
+              : "User",
+          })),
+        );
+      } catch {
+        // Skip comments on error
+      }
+    }
+  }
+
+  return {
+    projectNames,
+    agentNames,
+    goalTitles,
+    commentsByIssue,
+    folderStructure: config.folderStructure,
+    includeComments: config.includeComments,
+    maxCommentsPerIssue: config.maxCommentsPerIssue,
+  };
+}
+
+async function performSync(ctx: PluginContext): Promise<SyncResult> {
+  const syncedAt = new Date().toISOString();
+  const config = await getConfig(ctx);
+
+  if (!config.vaultPath && !config.gitRemoteUrl) {
+    return {
+      success: false,
+      issuesSynced: 0,
+      goalsSynced: 0,
+      filesWritten: 0,
+      gitCommitted: false,
+      gitPushed: false,
+      error: "No vault path or git remote URL configured",
+      syncedAt,
+    };
+  }
+
+  // Resolve company ID
+  const companies = await ctx.companies.list();
+  const companyId = companies[0]?.id;
+  if (!companyId) {
+    return {
+      success: false,
+      issuesSynced: 0,
+      goalsSynced: 0,
+      filesWritten: 0,
+      gitCommitted: false,
+      gitPushed: false,
+      error: "No company found",
+      syncedAt,
+    };
+  }
+
+  const vaultPath = await getVaultPath(config);
+
+  // Ensure git repo is ready if using git
+  if (config.gitRemoteUrl) {
+    const repoResult = await ensureRepo({
+      vaultPath,
+      gitRemoteUrl: config.gitRemoteUrl,
+      gitBranch: config.gitBranch,
+    });
+    if (repoResult.error) {
+      ctx.logger.warn("Git repo setup issue", { error: repoResult.error });
+    }
+  }
+
+  const notes: ObsidianNote[] = [];
+  let issuesSynced = 0;
+  let goalsSynced = 0;
+
+  // Fetch and map issues
+  if (config.syncEntities.includes("issues")) {
+    const issues = await ctx.issues.list({ companyId });
+    const mapperCtx = await buildMapperContext(ctx, config, companyId, issues);
+
+    for (const issue of issues) {
+      notes.push(mapIssueToNote(issue, mapperCtx));
+      issuesSynced++;
+    }
+  }
+
+  // Fetch and map goals
+  if (config.syncEntities.includes("goals")) {
+    const goals = await ctx.goals.list({ companyId });
+    const agentNames = new Map<string, string>();
+    const agents = await ctx.agents.list({ companyId });
+    for (const a of agents) {
+      agentNames.set(a.id, a.name);
+    }
+
+    const goalMapperCtx: MapperContext = {
+      projectNames: new Map(),
+      agentNames,
+      goalTitles: new Map(),
+      commentsByIssue: new Map(),
+      folderStructure: config.folderStructure,
+      includeComments: false,
+      maxCommentsPerIssue: 0,
+    };
+
+    for (const goal of goals) {
+      notes.push(mapGoalToNote(goal, goalMapperCtx));
+      goalsSynced++;
+    }
+  }
+
+  // Write notes to vault
+  const writtenPaths = await writeNotesToVault(vaultPath, notes);
+  ctx.logger.info("Notes written to vault", {
+    count: writtenPaths.length,
+    vaultPath,
+  });
+
+  // Commit and push if git is configured
+  let gitCommitted = false;
+  let gitPushed = false;
+
+  if (config.gitRemoteUrl) {
+    const gitResult = await commitAndPush({
+      vaultPath,
+      gitRemoteUrl: config.gitRemoteUrl,
+      gitBranch: config.gitBranch,
+      message: `sync: ${issuesSynced} issues, ${goalsSynced} goals [${syncedAt}]`,
+    });
+    gitCommitted = gitResult.committed;
+    gitPushed = gitResult.pushed;
+    if (gitResult.error) {
+      ctx.logger.warn("Git sync issue", { error: gitResult.error });
+    }
+  }
+
+  // Update sync cursor state
+  await ctx.state.set(
+    {
+      scopeKind: "company",
+      scopeId: companyId,
+      stateKey: STATE_KEYS.lastSyncCursor,
+    },
+    {
+      lastSyncAt: syncedAt,
+      issueCount: issuesSynced,
+      goalCount: goalsSynced,
+    } satisfies SyncCursor,
+  );
+
+  return {
+    success: true,
+    issuesSynced,
+    goalsSynced,
+    filesWritten: writtenPaths.length,
+    gitCommitted,
+    gitPushed,
+    syncedAt,
+  };
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info("Obsidian Vault Sync plugin starting");
+
+    // --- Scheduled sync job ---
+    ctx.jobs.register(JOB_KEYS.sync, async (_job: PluginJobContext) => {
+      ctx.logger.info("Starting scheduled Obsidian sync");
+      const result = await performSync(ctx);
+      ctx.logger.info("Sync completed", { result });
+    });
+
+    // --- Event subscriptions for incremental awareness ---
+    ctx.events.on("issue.created", async (event) => {
+      ctx.logger.debug("Issue created event received", {
+        entityId: event.entityId,
+      });
+    });
+
+    ctx.events.on("issue.updated", async (event) => {
+      ctx.logger.debug("Issue updated event received", {
+        entityId: event.entityId,
+      });
+    });
+
+    ctx.events.on("goal.created", async (event) => {
+      ctx.logger.debug("Goal created event received", {
+        entityId: event.entityId,
+      });
+    });
+
+    ctx.events.on("goal.updated", async (event) => {
+      ctx.logger.debug("Goal updated event received", {
+        entityId: event.entityId,
+      });
+    });
+
+    // --- Data handlers for UI ---
+    ctx.data.register(DATA_KEYS.syncHealth, async () => {
+      const companies = await ctx.companies.list();
+      const companyId = companies[0]?.id;
+      if (!companyId) {
+        return { status: "unconfigured", lastSync: null };
+      }
+
+      const cursor = (await ctx.state.get({
+        scopeKind: "company",
+        scopeId: companyId,
+        stateKey: STATE_KEYS.lastSyncCursor,
+      })) as SyncCursor | null;
+
+      const config = await getConfig(ctx);
+      const hasVault = Boolean(config.vaultPath || config.gitRemoteUrl);
+
+      return {
+        status: hasVault ? "configured" : "unconfigured",
+        lastSync: cursor,
+        vaultPath: config.vaultPath || "(git remote)",
+        gitRemoteUrl: config.gitRemoteUrl || null,
+        syncEntities: config.syncEntities,
+      };
+    });
+
+    ctx.data.register(DATA_KEYS.syncLog, async () => {
+      const companies = await ctx.companies.list();
+      const companyId = companies[0]?.id;
+      if (!companyId) return { entries: [] };
+
+      const cursor = (await ctx.state.get({
+        scopeKind: "company",
+        scopeId: companyId,
+        stateKey: STATE_KEYS.lastSyncCursor,
+      })) as SyncCursor | null;
+
+      return {
+        entries: cursor
+          ? [
+              {
+                syncedAt: cursor.lastSyncAt,
+                issueCount: cursor.issueCount,
+                goalCount: cursor.goalCount,
+              },
+            ]
+          : [],
+      };
+    });
+
+    // --- Action handlers ---
+    ctx.actions.register(ACTION_KEYS.triggerSync, async () => {
+      ctx.logger.info("Manual sync triggered from UI");
+      const result = await performSync(ctx);
+      return result;
+    });
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Obsidian Vault Sync plugin is healthy" };
+  },
+
+  async onConfigChanged(newConfig) {
+    // Config changes are handled on next sync run
+  },
+
+  async onValidateConfig(config) {
+    const c = config as Partial<ObsidianPluginConfig>;
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    if (!c.vaultPath && !c.gitRemoteUrl) {
+      warnings.push(
+        "Either vault path or git remote URL should be configured for sync to work.",
+      );
+    }
+
+    if (
+      c.syncIntervalMinutes !== undefined &&
+      (c.syncIntervalMinutes < 1 || c.syncIntervalMinutes > 1440)
+    ) {
+      errors.push("Sync interval must be between 1 and 1440 minutes.");
+    }
+
+    if (
+      c.maxCommentsPerIssue !== undefined &&
+      (c.maxCommentsPerIssue < 0 || c.maxCommentsPerIssue > 100)
+    ) {
+      errors.push("Max comments per issue must be between 0 and 100.");
+    }
+
+    return { ok: errors.length === 0, warnings, errors };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/plugin-obsidian/tests/mapper.spec.ts
+++ b/packages/plugins/plugin-obsidian/tests/mapper.spec.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapGoalToNote,
+  mapIssueToNote,
+  type MapperContext,
+} from "../src/lib/mapper.js";
+import type { Goal, Issue } from "@paperclipai/shared";
+
+function makeMapperCtx(overrides?: Partial<MapperContext>): MapperContext {
+  return {
+    projectNames: new Map([["proj_1", "Website"]]),
+    agentNames: new Map([["agent_1", "Founding Engineer"]]),
+    goalTitles: new Map([["goal_1", "Ship MVP"]]),
+    commentsByIssue: new Map(),
+    folderStructure: "by-project",
+    includeComments: true,
+    maxCommentsPerIssue: 10,
+    ...overrides,
+  };
+}
+
+function makeIssue(overrides?: Partial<Issue>): Issue {
+  return {
+    id: "iss_1",
+    companyId: "comp_1",
+    projectId: "proj_1",
+    projectWorkspaceId: null,
+    goalId: "goal_1",
+    parentId: null,
+    title: "Fix login bug",
+    description: "The login form breaks when PAP-99 is also broken.",
+    status: "in_progress",
+    priority: "high",
+    assigneeAgentId: "agent_1",
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    issueNumber: 42,
+    identifier: "PAP-42",
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    createdAt: new Date("2025-01-15T10:00:00Z"),
+    updatedAt: new Date("2025-01-16T12:00:00Z"),
+    ...overrides,
+  } as Issue;
+}
+
+describe("mapIssueToNote", () => {
+  it("generates correct path for by-project structure", () => {
+    const note = mapIssueToNote(makeIssue(), makeMapperCtx());
+    expect(note.relativePath).toBe("Projects/Website/Issues/PAP-42.md");
+  });
+
+  it("generates correct path for flat structure", () => {
+    const note = mapIssueToNote(
+      makeIssue(),
+      makeMapperCtx({ folderStructure: "flat" }),
+    );
+    expect(note.relativePath).toBe("Issues/PAP-42.md");
+  });
+
+  it("includes frontmatter fields", () => {
+    const note = mapIssueToNote(makeIssue(), makeMapperCtx());
+    expect(note.frontmatter.paperclip_id).toBe("iss_1");
+    expect(note.frontmatter.identifier).toBe("PAP-42");
+    expect(note.frontmatter.status).toBe("in_progress");
+    expect(note.frontmatter.priority).toBe("high");
+    expect(note.frontmatter.assignee).toBe("Founding Engineer");
+    expect(note.frontmatter.project).toBe("Website");
+    expect(note.frontmatter.goal).toBe("Ship MVP");
+    expect(note.frontmatter.tags).toEqual(["paperclip", "issue"]);
+  });
+
+  it("converts issue references to wikilinks", () => {
+    const note = mapIssueToNote(makeIssue(), makeMapperCtx());
+    expect(note.body).toContain("[[PAP-99]]");
+  });
+
+  it("includes comments when configured", () => {
+    const ctx = makeMapperCtx({
+      commentsByIssue: new Map([
+        [
+          "iss_1",
+          [
+            {
+              body: "Fixed the bug",
+              createdAt: "2025-01-16T12:00:00Z",
+              authorName: "Founding Engineer",
+            },
+          ],
+        ],
+      ]),
+    });
+    const note = mapIssueToNote(makeIssue(), ctx);
+    expect(note.body).toContain("## Comments");
+    expect(note.body).toContain("Fixed the bug");
+    expect(note.body).toContain("Founding Engineer");
+  });
+
+  it("handles uncategorized projects", () => {
+    const note = mapIssueToNote(
+      makeIssue({ projectId: "unknown_proj" }),
+      makeMapperCtx(),
+    );
+    expect(note.relativePath).toContain("Uncategorized");
+  });
+});
+
+describe("mapGoalToNote", () => {
+  it("generates a goal note with frontmatter", () => {
+    const goal: Goal = {
+      id: "goal_1",
+      companyId: "comp_1",
+      title: "Ship MVP",
+      description: "Launch the minimum viable product by Q1.",
+      level: "company",
+      status: "active",
+      parentId: null,
+      ownerAgentId: "agent_1",
+      createdAt: new Date("2025-01-01T00:00:00Z"),
+      updatedAt: new Date("2025-01-10T00:00:00Z"),
+    } as Goal;
+
+    const note = mapGoalToNote(goal, makeMapperCtx());
+    expect(note.relativePath).toBe("Goals/Ship MVP.md");
+    expect(note.frontmatter.paperclip_id).toBe("goal_1");
+    expect(note.frontmatter.level).toBe("company");
+    expect(note.frontmatter.status).toBe("active");
+    expect(note.frontmatter.owner).toBe("Founding Engineer");
+    expect(note.frontmatter.tags).toEqual(["paperclip", "goal"]);
+    expect(note.body).toContain("# Ship MVP");
+    expect(note.body).toContain("Launch the minimum viable product");
+  });
+});

--- a/packages/plugins/plugin-obsidian/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-obsidian/tests/plugin.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+describe("plugin-obsidian", () => {
+  it("registers sync-health data handler", async () => {
+    const harness = createTestHarness({
+      manifest,
+      capabilities: manifest.capabilities,
+    });
+
+    harness.seed({
+      companies: [
+        {
+          id: "comp_1",
+          name: "Test Co",
+          prefix: "TST",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    const data = await harness.getData<{ status: string }>("sync-health");
+    expect(data.status).toBe("unconfigured");
+  });
+
+  it("registers sync-log data handler", async () => {
+    const harness = createTestHarness({
+      manifest,
+      capabilities: manifest.capabilities,
+    });
+
+    harness.seed({
+      companies: [
+        {
+          id: "comp_1",
+          name: "Test Co",
+          prefix: "TST",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    const data = await harness.getData<{ entries: unknown[] }>("sync-log");
+    expect(data.entries).toEqual([]);
+  });
+
+  it("registers sync job handler", async () => {
+    const harness = createTestHarness({
+      manifest,
+      capabilities: manifest.capabilities,
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    // Job should be registered — running it without config should log a warning
+    // but not throw
+    await expect(harness.runJob("obsidian-sync")).resolves.not.toThrow();
+  });
+
+  it("subscribes to issue and goal events", async () => {
+    const harness = createTestHarness({
+      manifest,
+      capabilities: [...manifest.capabilities, "events.emit"],
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    // Should handle events without errors
+    await harness.emit(
+      "issue.created",
+      { issueId: "iss_1" },
+      { entityId: "iss_1", entityType: "issue" },
+    );
+    await harness.emit(
+      "issue.updated",
+      { issueId: "iss_1" },
+      { entityId: "iss_1", entityType: "issue" },
+    );
+    await harness.emit(
+      "goal.created",
+      { goalId: "goal_1" },
+      { entityId: "goal_1", entityType: "goal" },
+    );
+    await harness.emit(
+      "goal.updated",
+      { goalId: "goal_1" },
+      { entityId: "goal_1", entityType: "goal" },
+    );
+
+    // Events handled without throwing
+    expect(harness.logs.length).toBeGreaterThan(0);
+  });
+
+  it("validates config correctly", async () => {
+    const harness = createTestHarness({
+      manifest,
+      capabilities: manifest.capabilities,
+    });
+
+    await plugin.definition.setup(harness.ctx);
+
+    // Valid config with vault path
+    const validResult = await plugin.definition.onValidateConfig!({
+      vaultPath: "/tmp/vault",
+      syncIntervalMinutes: 15,
+    });
+    expect(validResult.ok).toBe(true);
+    expect(validResult.errors).toHaveLength(0);
+
+    // Config with no vault or git — should warn
+    const warnResult = await plugin.definition.onValidateConfig!({});
+    expect(warnResult.warnings.length).toBeGreaterThan(0);
+
+    // Invalid sync interval
+    const invalidResult = await plugin.definition.onValidateConfig!({
+      vaultPath: "/tmp/vault",
+      syncIntervalMinutes: 0,
+    });
+    expect(invalidResult.ok).toBe(false);
+    expect(invalidResult.errors.length).toBeGreaterThan(0);
+  });
+
+  it("reports healthy status", async () => {
+    const result = await plugin.definition.onHealth!();
+    expect(result.status).toBe("ok");
+  });
+});

--- a/packages/plugins/plugin-obsidian/tests/vault-writer.spec.ts
+++ b/packages/plugins/plugin-obsidian/tests/vault-writer.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { renderNote } from "../src/lib/vault-writer.js";
+import type { ObsidianNote } from "../src/lib/mapper.js";
+
+describe("renderNote", () => {
+  it("renders frontmatter and body", () => {
+    const note: ObsidianNote = {
+      relativePath: "Issues/PAP-42.md",
+      frontmatter: {
+        paperclip_id: "iss_1",
+        status: "in_progress",
+        tags: ["paperclip", "issue"],
+      },
+      body: "# Fix login bug\n\nDescription here.\n",
+    };
+
+    const rendered = renderNote(note);
+    expect(rendered).toContain("---");
+    expect(rendered).toContain("paperclip_id: iss_1");
+    expect(rendered).toContain("status: in_progress");
+    expect(rendered).toContain('  - "paperclip"');
+    expect(rendered).toContain('  - "issue"');
+    expect(rendered).toContain("# Fix login bug");
+  });
+
+  it("handles null values", () => {
+    const note: ObsidianNote = {
+      relativePath: "test.md",
+      frontmatter: { key: null },
+      body: "Body",
+    };
+
+    const rendered = renderNote(note);
+    expect(rendered).toContain("key: null");
+  });
+
+  it("handles empty arrays", () => {
+    const note: ObsidianNote = {
+      relativePath: "test.md",
+      frontmatter: { items: [] },
+      body: "Body",
+    };
+
+    const rendered = renderNote(note);
+    expect(rendered).toContain("items: []");
+  });
+
+  it("quotes strings with special YAML characters", () => {
+    const note: ObsidianNote = {
+      relativePath: "test.md",
+      frontmatter: { title: "Fix: something broken" },
+      body: "Body",
+    };
+
+    const rendered = renderNote(note);
+    expect(rendered).toContain('"Fix: something broken"');
+  });
+});

--- a/packages/plugins/plugin-obsidian/tsconfig.json
+++ b/packages/plugins/plugin-obsidian/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/plugin-obsidian/vitest.config.ts
+++ b/packages/plugins/plugin-obsidian/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

- Scaffolds `packages/plugins/plugin-obsidian/` — a connector plugin that syncs Paperclip issues and goals to an Obsidian vault as Markdown notes with YAML frontmatter and `[[wikilinks]]`
- Supports both local filesystem vaults and git-backed remote vaults (clone/pull/commit/push)
- Includes scheduled cron job (every 15min), event subscriptions for issue/goal changes, dashboard widget with manual sync trigger, and settings page
- 17 passing unit tests covering mapper, vault-writer, and plugin harness integration

## Test plan

- [x] `tsc --noEmit` passes (strict mode)
- [x] UI bundle builds via esbuild
- [x] 17/17 vitest tests pass (mapper, vault-writer, plugin harness)
- [ ] Manual: install plugin into running Paperclip instance and verify sync to local vault
- [ ] Manual: configure git remote URL and verify clone/commit/push flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)