### PR TITLE
feat: Dokploy MCP plugin (Phase 1)

### DIFF
--- a/packages/plugins/examples/plugin-dokploy-mcp/package.json
+++ b/packages/plugins/examples/plugin-dokploy-mcp/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@paperclipai/plugin-dokploy-mcp",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "prebuild": "node ../../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc && node ./scripts/build-ui.mjs",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@paperclipai/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "esbuild": "^0.27.3",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "~5.8.2"
+  }
+}

--- a/packages/plugins/examples/plugin-dokploy-mcp/scripts/build-ui.mjs
+++ b/packages/plugins/examples/plugin-dokploy-mcp/scripts/build-ui.mjs
@@ -1,0 +1,24 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@paperclipai/plugin-sdk/ui",
+  ],
+  logLevel: "info",
+});

--- a/packages/plugins/examples/plugin-dokploy-mcp/src/constants.ts
+++ b/packages/plugins/examples/plugin-dokploy-mcp/src/constants.ts
@@ -1,0 +1,22 @@
+export const PLUGIN_ID = "paperclip-dokploy-mcp";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const SLOT_IDS = {
+  settingsPage: "dokploy-mcp-settings-page",
+} as const;
+
+export const EXPORT_NAMES = {
+  settingsPage: "DokployMcpSettingsPage",
+} as const;
+
+export const TOOL_NAMES = {
+  getLogs: "dokploy-get-logs",
+  listApplications: "dokploy-list-applications",
+  getApplicationStatus: "dokploy-get-application-status",
+  redeploy: "dokploy-redeploy",
+  getApplicationStats: "dokploy-get-application-stats",
+} as const;
+
+export const DEFAULT_CONFIG = {
+  dokployMcpUrl: "",
+} as const;

--- a/packages/plugins/examples/plugin-dokploy-mcp/src/index.ts
+++ b/packages/plugins/examples/plugin-dokploy-mcp/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-dokploy-mcp/src/manifest.ts
+++ b/packages/plugins/examples/plugin-dokploy-mcp/src/manifest.ts
@@ -1,0 +1,132 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import {
+  DEFAULT_CONFIG,
+  EXPORT_NAMES,
+  PLUGIN_ID,
+  PLUGIN_VERSION,
+  SLOT_IDS,
+  TOOL_NAMES,
+} from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Dokploy MCP",
+  description:
+    "Wraps the Dokploy MCP server to expose infrastructure management tools to agents — view logs, list applications, check status, redeploy, and get resource stats.",
+  author: "Paperclip",
+  categories: ["connector", "automation"],
+  capabilities: [
+    "http.outbound",
+    "secrets.read-ref",
+    "agent.tools.register",
+    "activity.log.write",
+    "plugin.state.read",
+    "plugin.state.write",
+    "instance.settings.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      dokployMcpUrl: {
+        type: "string",
+        title: "Dokploy MCP URL",
+        description:
+          "HTTP endpoint for the Dokploy MCP server (e.g. http://dokploy-mcp:3001/mcp)",
+        default: DEFAULT_CONFIG.dokployMcpUrl,
+      },
+    },
+  },
+  tools: [
+    {
+      name: TOOL_NAMES.getLogs,
+      displayName: "Dokploy: Get Application Logs",
+      description:
+        "Retrieve container logs for a Dokploy application by its application ID.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          applicationId: {
+            type: "string",
+            description: "The Dokploy application ID.",
+          },
+        },
+        required: ["applicationId"],
+      },
+    },
+    {
+      name: TOOL_NAMES.listApplications,
+      displayName: "Dokploy: List Applications",
+      description: "List all applications managed by Dokploy.",
+      parametersSchema: {
+        type: "object",
+        properties: {},
+      },
+    },
+    {
+      name: TOOL_NAMES.getApplicationStatus,
+      displayName: "Dokploy: Get Application Status",
+      description:
+        "Get the current deployment status of a Dokploy application.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          applicationId: {
+            type: "string",
+            description: "The Dokploy application ID.",
+          },
+        },
+        required: ["applicationId"],
+      },
+    },
+    {
+      name: TOOL_NAMES.redeploy,
+      displayName: "Dokploy: Redeploy Application",
+      description:
+        "Trigger a redeployment of a Dokploy application. This is a mutating action and will be logged.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          applicationId: {
+            type: "string",
+            description: "The Dokploy application ID to redeploy.",
+          },
+        },
+        required: ["applicationId"],
+      },
+    },
+    {
+      name: TOOL_NAMES.getApplicationStats,
+      displayName: "Dokploy: Get Application Stats",
+      description:
+        "Get resource usage statistics (CPU, memory, etc.) for a Dokploy application.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          applicationId: {
+            type: "string",
+            description: "The Dokploy application ID.",
+          },
+        },
+        required: ["applicationId"],
+      },
+    },
+  ],
+  ui: {
+    slots: [
+      {
+        type: "settingsPage",
+        id: SLOT_IDS.settingsPage,
+        displayName: "Dokploy MCP Settings",
+        exportName: EXPORT_NAMES.settingsPage,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-dokploy-mcp/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-dokploy-mcp/src/ui/index.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState, type CSSProperties, type FormEvent } from "react";
+import type { PluginSettingsPageProps } from "@paperclipai/plugin-sdk/ui";
+import { DEFAULT_CONFIG, PLUGIN_ID } from "../constants.js";
+
+function hostFetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  return fetch(path, {
+    credentials: "include",
+    headers: {
+      "content-type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  }).then(async (response) => {
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `Request failed: ${response.status}`);
+    }
+    return (await response.json()) as T;
+  });
+}
+
+function useSettingsConfig() {
+  const [configJson, setConfigJson] = useState<Record<string, unknown>>({
+    ...DEFAULT_CONFIG,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    hostFetchJson<{ configJson?: Record<string, unknown> | null } | null>(
+      `/api/plugins/${PLUGIN_ID}/config`,
+    )
+      .then((result) => {
+        if (cancelled) return;
+        setConfigJson({ ...DEFAULT_CONFIG, ...(result?.configJson ?? {}) });
+        setError(null);
+      })
+      .catch((nextError) => {
+        if (cancelled) return;
+        setError(
+          nextError instanceof Error ? nextError.message : String(nextError),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function save(nextConfig: Record<string, unknown>) {
+    setSaving(true);
+    try {
+      await hostFetchJson(`/api/plugins/${PLUGIN_ID}/config`, {
+        method: "POST",
+        body: JSON.stringify({ configJson: nextConfig }),
+      });
+      setConfigJson(nextConfig);
+      setError(null);
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error ? nextError.message : String(nextError),
+      );
+      throw nextError;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return { configJson, setConfigJson, loading, saving, error, save };
+}
+
+const labelStyle: CSSProperties = {
+  display: "grid",
+  gap: "6px",
+  fontSize: "13px",
+};
+
+const inputStyle: CSSProperties = {
+  padding: "8px 10px",
+  fontSize: "13px",
+  borderRadius: "6px",
+  border: "1px solid var(--border-color, #d0d7de)",
+  background: "var(--input-bg, #fff)",
+  color: "var(--text-color, #1f2328)",
+  width: "100%",
+  boxSizing: "border-box",
+};
+
+const buttonStyle: CSSProperties = {
+  padding: "8px 16px",
+  fontSize: "13px",
+  fontWeight: 600,
+  borderRadius: "6px",
+  border: "1px solid var(--border-color, #d0d7de)",
+  background: "var(--button-bg, #f6f8fa)",
+  color: "var(--text-color, #1f2328)",
+  cursor: "pointer",
+};
+
+export function DokployMcpSettingsPage({ context }: PluginSettingsPageProps) {
+  const { configJson, setConfigJson, loading, saving, error, save } =
+    useSettingsConfig();
+  const [savedMessage, setSavedMessage] = useState<string | null>(null);
+
+  function setField(key: string, value: unknown) {
+    setConfigJson((current) => ({ ...current, [key]: value }));
+  }
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    await save(configJson);
+    setSavedMessage("Saved");
+    window.setTimeout(() => setSavedMessage(null), 1500);
+  }
+
+  if (loading) {
+    return (
+      <div style={{ fontSize: "12px", opacity: 0.7 }}>
+        Loading plugin config…
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} style={{ display: "grid", gap: "18px" }}>
+      <div>
+        <strong>Dokploy MCP Connection</strong>
+        <div style={{ fontSize: "13px", lineHeight: 1.5, marginTop: "6px" }}>
+          Configure the URL of your Dokploy MCP server. This plugin communicates
+          with the MCP server over HTTP using JSON-RPC 2.0 to provide
+          infrastructure management tools to agents.
+        </div>
+      </div>
+
+      <label style={labelStyle}>
+        <span>Dokploy MCP URL</span>
+        <input
+          type="url"
+          placeholder="http://dokploy-mcp:3001/mcp"
+          value={(configJson.dokployMcpUrl as string) ?? ""}
+          onChange={(event) => setField("dokployMcpUrl", event.target.value)}
+          style={inputStyle}
+        />
+        <span style={{ fontSize: "11px", opacity: 0.6 }}>
+          The HTTP endpoint for the Dokploy MCP server (e.g.
+          http://dokploy-mcp:3001/mcp)
+        </span>
+      </label>
+
+      {error && (
+        <div
+          style={{
+            color: "var(--danger-color, #cf222e)",
+            fontSize: "12px",
+            padding: "8px",
+            borderRadius: "6px",
+            background: "var(--danger-bg, #ffebe9)",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+        <button type="submit" disabled={saving} style={buttonStyle}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+        {savedMessage && (
+          <span style={{ fontSize: "12px", color: "var(--success-color, #1a7f37)" }}>
+            {savedMessage}
+          </span>
+        )}
+      </div>
+
+      <div style={{ marginTop: "8px" }}>
+        <strong>Available Tools</strong>
+        <div
+          style={{
+            fontSize: "12px",
+            lineHeight: 1.8,
+            marginTop: "6px",
+            opacity: 0.8,
+          }}
+        >
+          <div>
+            <code>dokploy-get-logs</code> — Retrieve container logs
+          </div>
+          <div>
+            <code>dokploy-list-applications</code> — List all applications
+          </div>
+          <div>
+            <code>dokploy-get-application-status</code> — Get deployment status
+          </div>
+          <div>
+            <code>dokploy-redeploy</code> — Trigger redeployment
+          </div>
+          <div>
+            <code>dokploy-get-application-stats</code> — Resource usage stats
+          </div>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/packages/plugins/examples/plugin-dokploy-mcp/src/worker.ts
+++ b/packages/plugins/examples/plugin-dokploy-mcp/src/worker.ts
@@ -1,0 +1,320 @@
+import {
+  definePlugin,
+  runWorker,
+  type PaperclipPlugin,
+  type PluginContext,
+  type PluginConfigValidationResult,
+  type PluginHealthDiagnostics,
+  type ToolResult,
+  type ToolRunContext,
+} from "@paperclipai/plugin-sdk";
+import { DEFAULT_CONFIG, PLUGIN_ID, TOOL_NAMES } from "./constants.js";
+
+type DokployConfig = {
+  dokployMcpUrl?: string;
+};
+
+let _jsonRpcId = 0;
+function nextId() {
+  return ++_jsonRpcId;
+}
+
+function extractText(
+  result: { content?: Array<{ text?: string }> } | undefined | null,
+): string {
+  return (
+    result?.content
+      ?.map((c) => c.text ?? "")
+      .join("\n")
+      .trim() ?? ""
+  );
+}
+
+async function getConfig(ctx: PluginContext): Promise<DokployConfig> {
+  const config = await ctx.config.get();
+  return { ...DEFAULT_CONFIG, ...(config as DokployConfig) };
+}
+
+async function callMcpTool(
+  ctx: PluginContext,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const config = await getConfig(ctx);
+  const url = config.dokployMcpUrl;
+
+  if (!url) {
+    throw new Error(
+      "Dokploy MCP URL is not configured. Set it in the plugin settings.",
+    );
+  }
+
+  const body = {
+    jsonrpc: "2.0",
+    id: nextId(),
+    method: "tools/call",
+    params: { name: toolName, arguments: args },
+  };
+
+  const res = await ctx.http.fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "(unreadable)");
+    throw new Error(`Dokploy MCP returned HTTP ${res.status}: ${text}`);
+  }
+
+  const json = (await res.json()) as {
+    result?: { content?: Array<{ text?: string }> };
+    error?: { code: number; message: string };
+  };
+
+  if (json.error) {
+    throw new Error(`Dokploy MCP error: ${json.error.message}`);
+  }
+
+  return json.result;
+}
+
+function registerTools(ctx: PluginContext): void {
+  // dokploy-get-logs
+  ctx.tools.register(
+    TOOL_NAMES.getLogs,
+    {
+      displayName: "Dokploy: Get Application Logs",
+      description:
+        "Retrieve container logs for a Dokploy application by its application ID.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          applicationId: {
+            type: "string",
+            description: "The Dokploy application ID.",
+          },
+        },
+        required: ["applicationId"],
+      },
+    },
+    async (params, runCtx): Promise<ToolResult> => {
+      const { applicationId } = params as { applicationId: string };
+      if (!applicationId) return { error: "applicationId is required" };
+
+      const result = await callMcpTool(ctx, "get-application-logs", {
+        applicationId,
+      });
+
+      const logs = extractText(
+        result as { content?: Array<{ text?: string }> },
+      );
+
+      await ctx.activity.log({
+        companyId: runCtx.companyId,
+        message: `Retrieved logs for application ${applicationId}`,
+        metadata: { tool: TOOL_NAMES.getLogs, applicationId },
+      });
+
+      return {
+        content: logs || "(no logs returned)",
+        data: { applicationId, logsLength: logs.length },
+      };
+    },
+  );
+
+  // dokploy-list-applications
+  ctx.tools.register(
+    TOOL_NAMES.listApplications,
+    {
+      displayName: "Dokploy: List Applications",
+      description: "List all applications managed by Dokploy.",
+      parametersSchema: { type: "object", properties: {} },
+    },
+    async (_params, runCtx): Promise<ToolResult> => {
+      const result = await callMcpTool(ctx, "list-applications", {});
+      const text = extractText(
+        result as { content?: Array<{ text?: string }> },
+      );
+
+      await ctx.activity.log({
+        companyId: runCtx.companyId,
+        message: "Listed all Dokploy applications",
+        metadata: { tool: TOOL_NAMES.listApplications },
+      });
+
+      return { content: text || "(no applications found)", data: { raw: text } };
+    },
+  );
+
+  // dokploy-get-application-status
+  ctx.tools.register(
+    TOOL_NAMES.getApplicationStatus,
+    {
+      displayName: "Dokploy: Get Application Status",
+      description:
+        "Get the current deployment status of a Dokploy application.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          applicationId: {
+            type: "string",
+            description: "The Dokploy application ID.",
+          },
+        },
+        required: ["applicationId"],
+      },
+    },
+    async (params, runCtx): Promise<ToolResult> => {
+      const { applicationId } = params as { applicationId: string };
+      if (!applicationId) return { error: "applicationId is required" };
+
+      const result = await callMcpTool(ctx, "get-application-status", {
+        applicationId,
+      });
+
+      const text = extractText(
+        result as { content?: Array<{ text?: string }> },
+      );
+
+      await ctx.activity.log({
+        companyId: runCtx.companyId,
+        message: `Checked status of application ${applicationId}`,
+        metadata: { tool: TOOL_NAMES.getApplicationStatus, applicationId },
+      });
+
+      return {
+        content: text || "(no status returned)",
+        data: { applicationId },
+      };
+    },
+  );
+
+  // dokploy-redeploy
+  ctx.tools.register(
+    TOOL_NAMES.redeploy,
+    {
+      displayName: "Dokploy: Redeploy Application",
+      description:
+        "Trigger a redeployment of a Dokploy application. This is a mutating action.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          applicationId: {
+            type: "string",
+            description: "The Dokploy application ID to redeploy.",
+          },
+        },
+        required: ["applicationId"],
+      },
+    },
+    async (params, runCtx): Promise<ToolResult> => {
+      const { applicationId } = params as { applicationId: string };
+      if (!applicationId) return { error: "applicationId is required" };
+
+      const result = await callMcpTool(ctx, "redeploy-application", {
+        applicationId,
+      });
+
+      const text = extractText(
+        result as { content?: Array<{ text?: string }> },
+      );
+
+      await ctx.activity.log({
+        companyId: runCtx.companyId,
+        message: `Triggered redeployment of application ${applicationId}`,
+        metadata: {
+          tool: TOOL_NAMES.redeploy,
+          applicationId,
+          action: "redeploy",
+        },
+      });
+
+      return {
+        content: text || `Redeployment triggered for ${applicationId}`,
+        data: { applicationId, action: "redeploy" },
+      };
+    },
+  );
+
+  // dokploy-get-application-stats
+  ctx.tools.register(
+    TOOL_NAMES.getApplicationStats,
+    {
+      displayName: "Dokploy: Get Application Stats",
+      description:
+        "Get resource usage statistics (CPU, memory, etc.) for a Dokploy application.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          applicationId: {
+            type: "string",
+            description: "The Dokploy application ID.",
+          },
+        },
+        required: ["applicationId"],
+      },
+    },
+    async (params, runCtx): Promise<ToolResult> => {
+      const { applicationId } = params as { applicationId: string };
+      if (!applicationId) return { error: "applicationId is required" };
+
+      const result = await callMcpTool(ctx, "get-application-stats", {
+        applicationId,
+      });
+
+      const text = extractText(
+        result as { content?: Array<{ text?: string }> },
+      );
+
+      await ctx.activity.log({
+        companyId: runCtx.companyId,
+        message: `Retrieved stats for application ${applicationId}`,
+        metadata: { tool: TOOL_NAMES.getApplicationStats, applicationId },
+      });
+
+      return {
+        content: text || "(no stats returned)",
+        data: { applicationId },
+      };
+    },
+  );
+}
+
+const plugin: PaperclipPlugin = definePlugin({
+  async setup(ctx: PluginContext) {
+    registerTools(ctx);
+    ctx.logger.info("Dokploy MCP plugin initialized");
+  },
+
+  async onHealth(): Promise<PluginHealthDiagnostics> {
+    return { status: "ok", message: "Dokploy MCP plugin ready" };
+  },
+
+  async onConfigChanged(newConfig: Record<string, unknown>): Promise<void> {
+    // Config is read on each tool call, no caching needed
+  },
+
+  async onValidateConfig(
+    config: Record<string, unknown>,
+  ): Promise<PluginConfigValidationResult> {
+    const url = config.dokployMcpUrl as string | undefined;
+    if (url && typeof url === "string") {
+      try {
+        new URL(url);
+      } catch {
+        return {
+          ok: false,
+          errors: ["dokployMcpUrl: Must be a valid URL"],
+        };
+      }
+    }
+    return { ok: true };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-dokploy-mcp/tsconfig.json
+++ b/packages/plugins/examples/plugin-dokploy-mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,37 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/plugins/examples/plugin-dokploy-mcp:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../../../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ~5.8.2
+        version: 5.8.3
+
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
       '@codemirror/lang-javascript':
@@ -5994,6 +6025,11 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -12709,6 +12745,8 @@ snapshots:
   type@2.7.3: {}
 
   typedarray@0.0.6: {}
+
+  typescript@5.8.3: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary

- Scaffolds new plugin at `packages/plugins/examples/plugin-dokploy-mcp/`
- Exposes 5 Dokploy infrastructure tools to agents via MCP JSON-RPC bridge:
  - `dokploy-get-logs` — retrieve container logs
  - `dokploy-list-applications` — list all Dokploy applications
  - `dokploy-get-application-status` — get deployment status
  - `dokploy-redeploy` — trigger redeployment (mutating, audit-logged)
  - `dokploy-get-application-stats` — resource usage stats
- Settings page for configuring `DOKPLOY_MCP_URL` via plugin instance config
- All infrastructure actions logged via plugin activity system for audit trail
- URL validation in `onValidateConfig`

## Reference

- Resolves PAP-54
- Plan: PAP-51

## Test plan

- [ ] Plugin builds cleanly
- [ ] Plugin typechecks
- [ ] Settings page renders and saves MCP URL config
- [ ] Each tool returns correct MCP response when Dokploy MCP server is available
- [ ] Activity log entries created for each tool invocation
- [ ] Invalid URL rejected by config validation

Generated with Claude Code