### PR TITLE
fix: add missing docs pages to navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,7 +79,8 @@
               "deploy/database",
               "deploy/secrets",
               "deploy/storage",
-              "deploy/environment-variables"
+              "deploy/environment-variables",
+              "deploy/branching-workflow"
             ]
           }
         ]
@@ -93,6 +94,7 @@
               "adapters/overview",
               "adapters/claude-local",
               "adapters/codex-local",
+              "adapters/gemini-local",
               "adapters/process",
               "adapters/http",
               "adapters/creating-an-adapter"


### PR DESCRIPTION
## Summary

- Add `adapters/gemini-local` to the Adapters tab in docs navigation
- Add `deploy/branching-workflow` to the Deploy tab in docs navigation
- Both markdown files already existed but were not discoverable through the Mintlify nav

Closes PAP-57 — the documentation site is already fully built out with Mintlify covering all required scope (core concepts, API reference, getting started, deployment guides). These were the only two navigation gaps.

## Test plan

- [ ] Verify Mintlify renders both new nav entries correctly
- [ ] Confirm all other nav links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)