### PR TITLE
Add community contribution workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug Report
+description: Report a bug in Paperclip
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear, concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Relevant environment details.
+      placeholder: |
+        - OS: [e.g. macOS 14, Ubuntu 22.04]
+        - Node.js: [e.g. 20.x]
+        - Browser: [e.g. Chrome 120]
+        - Paperclip version/commit: [e.g. v0.1.0 or commit hash]
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Paste any relevant log output or screenshots.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord
+    url: https://discord.gg/paperclip
+    about: Ask questions and discuss ideas in the #dev channel

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature. Please describe what you'd like and why it matters.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? What's the pain point?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this work? Include any design ideas or API sketches.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any other approaches you considered and why they don't work as well.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, mockups, related issues, or links.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Thinking Path
+
+> - Paperclip orchestrates AI agents for zero-human companies
+> - [Describe the area of the system this touches]
+> - [Describe the problem or gap]
+> - [Describe what this PR does about it]
+> - [Describe the benefit]
+
+## What Changed
+
+<!-- Describe what you changed and why. -->
+
+## How to Verify
+
+<!-- Steps to test this manually, or note which automated tests cover it. -->
+
+## Screenshots
+
+<!-- Before/after screenshots for UI changes. Remove this section if not applicable. -->
+
+## Checklist
+
+- [ ] `pnpm -r typecheck` passes
+- [ ] `pnpm test:run` passes
+- [ ] `pnpm build` succeeds
+- [ ] Commit messages are clear and descriptive
+- [ ] No new lint warnings introduced

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,24 @@ Thanks for wanting to contribute!
 
 We really appreciate both small fixes and thoughtful larger changes.
 
+## Getting Started
+
+1. Fork the repo and clone your fork
+2. Install dependencies: `pnpm install`
+3. Start the dev server: `pnpm dev` (API + UI on `:3100`)
+4. Make your changes on a feature branch
+5. Run the verification checklist before submitting
+
+### Verification Checklist
+
+Before opening a PR, make sure all three pass:
+
+```sh
+pnpm -r typecheck   # Type-check all packages
+pnpm test:run       # Run unit tests
+pnpm build          # Build all packages
+```
+
 ## Two Paths to Get Your Pull Request Accepted
 
 ### Path 1: Small, Focused Changes (Fastest way to get merged)
@@ -18,8 +36,8 @@ These almost always get merged quickly when they're clean.
 
 ### Path 2: Bigger or Impactful Changes
 
-- **First** talk about it in Discord → #dev channel  
-  → Describe what you're trying to solve  
+- **First** talk about it in Discord → #dev channel
+  → Describe what you're trying to solve
   → Share rough ideas / approach
 - Once there's rough agreement, build it
 - In your PR include:
@@ -31,13 +49,23 @@ These almost always get merged quickly when they're clean.
 
 PRs that follow this path are **much** more likely to be accepted, even when they're large.
 
+## Coding Standards
+
+- **TypeScript** for all server and UI code. No `any` unless unavoidable (and commented why).
+- **Formatting**: Follow the existing code style. Use the project's ESLint and Prettier config.
+- **Imports**: Use path aliases where defined. Keep imports organized (external, then internal, then relative).
+- **Naming**: `camelCase` for variables and functions, `PascalCase` for types/components, `UPPER_SNAKE` for constants.
+- **Tests**: Add tests for new logic. Don't skip existing tests. Use Vitest for unit tests, Playwright for e2e.
+- **Database changes**: Run `pnpm db:generate` after modifying the Drizzle schema. Include the generated migration in your PR.
+- **No secrets**: Never commit `.env` files, API keys, or credentials.
+
 ## General Rules (both paths)
 
 - Write clear commit messages
 - Keep PR title + description meaningful
 - One PR = one logical change (unless it's a small related group)
 - Run tests locally first
-- Be kind in discussions 😄
+- Be kind in discussions
 
 ## Writing a Good PR message
 
@@ -69,6 +97,60 @@ This should include details about what you did, why you did it, why it matters &
 
 Please include screenshots if possible if you have a visible change. (use something like the [agent-browser skill](https://github.com/vercel-labs/agent-browser/blob/main/skills/agent-browser/SKILL.md) or similar to take screenshots). Ideally, you include before and after screenshots.
 
-Questions? Just ask in #dev — we're happy to help.
+## Issue Labels
+
+We use labels to categorize and prioritize issues:
+
+| Label | Description |
+|-------|-------------|
+| `bug` | Something is broken |
+| `enhancement` | New feature or improvement |
+| `documentation` | Documentation only changes |
+| `good first issue` | Good for newcomers to the project |
+| `help wanted` | Extra attention needed from the community |
+| `triage` | Needs review and categorization |
+| `duplicate` | Already reported |
+| `wontfix` | Not planned |
+| `breaking` | Introduces a breaking change |
+| `security` | Security-related issue |
+| `performance` | Performance improvement |
+| `ui` | Frontend / UI issue |
+| `api` | Backend / API issue |
+| `adapters` | Agent adapter related |
+| `plugins` | Plugin system related |
+| `infra` | CI/CD, deployment, infrastructure |
+
+## Review Process
+
+1. **Automated checks** run on every PR (typecheck, tests, build, Greptile review).
+2. **Triage**: Maintainers label and prioritize incoming issues and PRs within 3 business days.
+3. **Code review**: A maintainer will review your PR. Expect initial feedback within 5 business days for small PRs, 10 business days for larger ones.
+4. **Iteration**: Address review comments, push updates, and re-request review.
+5. **Merge**: Once approved and all checks pass, a maintainer will merge your PR.
+
+### Response SLAs
+
+| Action | Target |
+|--------|--------|
+| Issue triage (label + priority) | 3 business days |
+| First review on small PRs (< 200 lines) | 5 business days |
+| First review on large PRs (200+ lines) | 10 business days |
+| Follow-up review after changes | 3 business days |
+
+These are targets, not guarantees. We're a small team and prioritize quality over speed.
+
+## Contributor License Agreement (CLA)
+
+By submitting a pull request, you agree that your contributions are licensed under the same license as the project (see [LICENSE](./LICENSE)). You certify that:
+
+- The contribution is your original work, or you have the right to submit it.
+- You grant the project maintainers a perpetual, worldwide, non-exclusive, royalty-free license to use, reproduce, and distribute your contribution.
+- You understand the contribution is public and a record of it (including your name and email) is maintained indefinitely.
+
+No separate CLA form is required — submitting a PR constitutes acceptance.
+
+## Questions?
+
+Just ask in #dev — we're happy to help.
 
 Happy hacking!


### PR DESCRIPTION
## Summary

- Added GitHub issue templates (bug report + feature request) with structured YAML forms
- Added PR template with thinking-path structure and verification checklist
- Updated CONTRIBUTING.md with getting started guide, coding standards, label taxonomy, review process with response SLAs, and inline CLA

## Test plan

- [ ] Verify issue templates render correctly on GitHub (New Issue page)
- [ ] Verify PR template auto-populates when opening a new PR
- [ ] Review CONTRIBUTING.md content for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)