### PR TITLE
feat: move Claude Code hooks into git repo

### DIFF
--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Block --no-verify flag in git commands.
+# Agents must fix underlying issues instead of bypassing hooks.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract command using node (jq not available)
+command=$(echo "$input" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try { const o=JSON.parse(d); console.log(o.tool_input?.command||''); }
+    catch(e) { console.log(''); }
+  });
+")
+
+if [ -z "$command" ]; then
+  exit 0
+fi
+
+if echo "$command" | grep -qE '(^|\s)--no-verify(\s|$)'; then
+  echo "BLOCKED: --no-verify is not allowed. Fix the underlying hook failure instead of bypassing it."
+  exit 2
+fi

--- a/.claude/hooks/track-cost.sh
+++ b/.claude/hooks/track-cost.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Stop hook: Track session cost and token usage.
+# Appends a line to a cost log for budget visibility.
+
+set -uo pipefail
+
+input=$(cat)
+log_dir="${CLAUDE_LOG_DIR:-/tmp/claude-cost-logs}"
+log_file="$log_dir/session-costs.jsonl"
+mkdir -p "$log_dir"
+
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+agent_id="${PAPERCLIP_AGENT_ID:-unknown}"
+run_id="${PAPERCLIP_RUN_ID:-unknown}"
+
+# Parse and log using node
+echo "$input" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    let o={};
+    try { o=JSON.parse(d); } catch(e) {}
+    const entry = {
+      timestamp: '$timestamp',
+      agent_id: '$agent_id',
+      run_id: '$run_id',
+      session_id: o.session_id || 'unknown',
+      cost_usd: o.total_cost_usd || 0,
+      input_tokens: o.total_input_tokens || 0,
+      output_tokens: o.total_output_tokens || 0,
+      duration_sec: o.duration_seconds || 0,
+      stop_reason: o.stop_reason || 'unknown'
+    };
+    const fs = require('fs');
+    fs.appendFileSync('$log_file', JSON.stringify(entry) + '\n');
+    console.log('Session cost logged: \$' + entry.cost_usd + ' | ' + entry.input_tokens + 'in/' + entry.output_tokens + 'out tokens | ' + entry.duration_sec + 's');
+  });
+"

--- a/.claude/hooks/typecheck-on-edit.sh
+++ b/.claude/hooks/typecheck-on-edit.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PostToolUse hook: Run typecheck after TypeScript file edits.
+# Only triggers for .ts/.tsx file modifications to avoid unnecessary runs.
+
+set -uo pipefail
+
+input=$(cat)
+
+# Extract file_path using node
+file_path=$(echo "$input" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const o=JSON.parse(d);
+      console.log(o.tool_input?.file_path || o.tool_input?.notebook_path || '');
+    } catch(e) { console.log(''); }
+  });
+")
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# Only typecheck TypeScript files
+case "$file_path" in
+  *.ts|*.tsx) ;;
+  *) exit 0 ;;
+esac
+
+# Find the nearest package.json with a typecheck script
+dir=$(dirname "$file_path")
+pkg_dir=""
+while [ "$dir" != "/" ]; do
+  if [ -f "$dir/package.json" ] && grep -q '"typecheck"' "$dir/package.json" 2>/dev/null; then
+    pkg_dir="$dir"
+    break
+  fi
+  dir=$(dirname "$dir")
+done
+
+if [ -z "$pkg_dir" ]; then
+  exit 0
+fi
+
+# Debounce: skip if last typecheck was < 30s ago
+stamp_file="/tmp/.claude-typecheck-stamp"
+now=$(date +%s)
+if [ -f "$stamp_file" ]; then
+  last=$(cat "$stamp_file")
+  if [ $((now - last)) -lt 30 ]; then
+    exit 0
+  fi
+fi
+echo "$now" > "$stamp_file"
+
+echo "Running typecheck in $(basename "$pkg_dir")..."
+cd "$pkg_dir"
+if ! pnpm typecheck 2>&1 | tail -30; then
+  echo "Typecheck failed - please fix before continuing."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-no-verify.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/typecheck-on-edit.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/track-cost.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Moves Claude Code hook scripts (`block-no-verify.sh`, `typecheck-on-edit.sh`, `track-cost.sh`) and `settings.json` into the repo's `.claude/` directory
- Hooks now persist across fresh clones instead of living only in the container config
- `settings.json` uses relative paths so it works when running Claude from the repo root

## Context

Board user requested this in PAP-83 — hooks were previously only in the container's `/paperclip/.claude/` and lost on re-clone.

## Test plan

- [ ] Verify hooks are present after fresh clone
- [ ] Verify `--no-verify` is still blocked by PreToolUse hook
- [ ] Verify typecheck runs after `.ts` file edits
- [ ] Verify cost tracking logs on session stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)