### PR TITLE
feat: Sentry plugin with agent tools and UI error dashboard

### DIFF
--- a/packages/plugins/plugin-sentry/package.json
+++ b/packages/plugins/plugin-sentry/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@paperclipai/plugin-sentry",
+  "version": "0.1.0",
+  "description": "Sentry integration plugin: agent tools for error diagnostics and UI error dashboard for the board",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "node ../../../scripts/ensure-plugin-build-deps.mjs",
+    "build": "tsc && node ./scripts/build-ui.mjs",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk build && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@paperclipai/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "esbuild": "^0.27.3",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/plugin-sentry/scripts/build-ui.mjs
+++ b/packages/plugins/plugin-sentry/scripts/build-ui.mjs
@@ -1,0 +1,24 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@paperclipai/plugin-sdk/ui",
+  ],
+  logLevel: "info",
+});

--- a/packages/plugins/plugin-sentry/src/constants.ts
+++ b/packages/plugins/plugin-sentry/src/constants.ts
@@ -1,0 +1,36 @@
+export const PLUGIN_ID = "paperclip-sentry";
+export const PLUGIN_VERSION = "0.1.0";
+export const PAGE_ROUTE = "sentry";
+
+export const SLOT_IDS = {
+  page: "sentry-page",
+  settingsPage: "sentry-settings-page",
+  dashboardWidget: "sentry-dashboard-widget",
+  sidebar: "sentry-sidebar-link",
+} as const;
+
+export const EXPORT_NAMES = {
+  page: "SentryPage",
+  settingsPage: "SentrySettingsPage",
+  dashboardWidget: "SentryDashboardWidget",
+  sidebar: "SentrySidebarLink",
+} as const;
+
+export const TOOL_NAMES = {
+  listIssues: "sentry.list-issues",
+  getIssue: "sentry.get-issue",
+  search: "sentry.search",
+} as const;
+
+export const DATA_KEYS = {
+  overview: "overview",
+  issueDetail: "issue-detail",
+  issueEvents: "issue-events",
+} as const;
+
+export const DEFAULT_CONFIG = {
+  authToken: "",
+  organizationSlug: "",
+  projectSlug: "",
+  sentryBaseUrl: "https://sentry.io",
+} as const;

--- a/packages/plugins/plugin-sentry/src/index.ts
+++ b/packages/plugins/plugin-sentry/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export * from "./constants.js";

--- a/packages/plugins/plugin-sentry/src/manifest.ts
+++ b/packages/plugins/plugin-sentry/src/manifest.ts
@@ -1,0 +1,172 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import {
+  DEFAULT_CONFIG,
+  EXPORT_NAMES,
+  PAGE_ROUTE,
+  PLUGIN_ID,
+  PLUGIN_VERSION,
+  SLOT_IDS,
+  TOOL_NAMES,
+} from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Sentry",
+  description:
+    "Sentry error tracking integration. Provides agent tools for querying production errors and a UI dashboard for the board to visualize captured issues.",
+  author: "Paperclip",
+  categories: ["connector", "ui"],
+  capabilities: [
+    "http.outbound",
+    "secrets.read-ref",
+    "plugin.state.read",
+    "plugin.state.write",
+    "agent.tools.register",
+    "instance.settings.register",
+    "ui.sidebar.register",
+    "ui.page.register",
+    "ui.dashboardWidget.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      authToken: {
+        type: "string",
+        title: "Sentry Auth Token",
+        description: "Scoped API token from Sentry (org:read, project:read, event:read).",
+        default: DEFAULT_CONFIG.authToken,
+      },
+      organizationSlug: {
+        type: "string",
+        title: "Organization Slug",
+        description: "Your Sentry organization slug.",
+        default: DEFAULT_CONFIG.organizationSlug,
+      },
+      projectSlug: {
+        type: "string",
+        title: "Project Slug",
+        description: "Your Sentry project slug. Leave empty to query across all org projects.",
+        default: DEFAULT_CONFIG.projectSlug,
+      },
+      sentryBaseUrl: {
+        type: "string",
+        title: "Sentry Base URL",
+        description: "Base URL for Sentry API (self-hosted instances).",
+        default: DEFAULT_CONFIG.sentryBaseUrl,
+      },
+    },
+    required: ["authToken", "organizationSlug"],
+  },
+  tools: [
+    {
+      name: TOOL_NAMES.listIssues,
+      displayName: "List Sentry Issues",
+      description:
+        "List recent Sentry issues filtered by project, level (error/warning/fatal), and status (resolved/unresolved).",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Sentry search query (e.g. 'is:unresolved level:error').",
+          },
+          project: {
+            type: "string",
+            description: "Project slug to filter by. Uses configured default if omitted.",
+          },
+          limit: {
+            type: "number",
+            description: "Max issues to return (default 25, max 100).",
+          },
+          sort: {
+            type: "string",
+            enum: ["date", "new", "freq", "priority"],
+            description: "Sort order (default: date).",
+          },
+        },
+      },
+    },
+    {
+      name: TOOL_NAMES.getIssue,
+      displayName: "Get Sentry Issue Detail",
+      description:
+        "Get detailed information about a Sentry issue including stacktrace, recent events, and tags.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          issueId: {
+            type: "string",
+            description: "Sentry issue ID.",
+          },
+        },
+        required: ["issueId"],
+      },
+    },
+    {
+      name: TOOL_NAMES.search,
+      displayName: "Search Sentry Errors",
+      description:
+        "Search Sentry errors by query string (message, tag, fingerprint, etc.).",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Free-text search query.",
+          },
+          level: {
+            type: "string",
+            enum: ["fatal", "error", "warning", "info", "debug"],
+            description: "Filter by error level.",
+          },
+          dateRange: {
+            type: "string",
+            description: "Time range (e.g. '24h', '7d', '30d'). Default: 24h.",
+          },
+          limit: {
+            type: "number",
+            description: "Max results (default 25, max 100).",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  ],
+  ui: {
+    slots: [
+      {
+        type: "page",
+        id: SLOT_IDS.page,
+        displayName: "Sentry Errors",
+        exportName: EXPORT_NAMES.page,
+        routePath: PAGE_ROUTE,
+      },
+      {
+        type: "settingsPage",
+        id: SLOT_IDS.settingsPage,
+        displayName: "Sentry Settings",
+        exportName: EXPORT_NAMES.settingsPage,
+      },
+      {
+        type: "dashboardWidget",
+        id: SLOT_IDS.dashboardWidget,
+        displayName: "Sentry Errors",
+        exportName: EXPORT_NAMES.dashboardWidget,
+      },
+      {
+        type: "sidebar",
+        id: SLOT_IDS.sidebar,
+        displayName: "Sentry",
+        exportName: EXPORT_NAMES.sidebar,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/plugin-sentry/src/ui/index.tsx
+++ b/packages/plugins/plugin-sentry/src/ui/index.tsx
@@ -1,0 +1,607 @@
+import { useState, type CSSProperties } from "react";
+import {
+  useHostContext,
+  usePluginData,
+  type PluginPageProps,
+  type PluginSettingsPageProps,
+  type PluginSidebarProps,
+  type PluginWidgetProps,
+} from "@paperclipai/plugin-sdk/ui";
+import { DATA_KEYS, PLUGIN_ID, PAGE_ROUTE } from "../constants.js";
+
+// ---------------------------------------------------------------------------
+// Shared types & styles
+// ---------------------------------------------------------------------------
+
+type SentryIssueRow = {
+  id: string;
+  shortId: string;
+  title: string;
+  level: string;
+  status: string;
+  count: string;
+  userCount: number;
+  lastSeen: string;
+  firstSeen: string;
+  culprit: string;
+  project: string;
+  permalink: string;
+};
+
+type OverviewData = {
+  configured: boolean;
+  issues: SentryIssueRow[];
+  error?: string;
+};
+
+type IssueDetailData = {
+  issue: SentryIssueRow & { metadata: Record<string, unknown> };
+  latestEvent: {
+    eventID: string;
+    title: string;
+    message: string;
+    dateCreated: string;
+    tags: Array<{ key: string; value: string }>;
+  } | null;
+  stacktrace: unknown;
+  breadcrumbs: unknown;
+  events: Array<{
+    eventID: string;
+    title: string;
+    message: string;
+    dateCreated: string;
+    tags: Array<{ key: string; value: string }>;
+  }>;
+};
+
+const styles = {
+  container: {
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    color: "#e0e0e0",
+    padding: "16px",
+  } satisfies CSSProperties,
+  card: {
+    background: "rgba(255,255,255,0.04)",
+    borderRadius: "8px",
+    border: "1px solid rgba(255,255,255,0.08)",
+    padding: "16px",
+    marginBottom: "12px",
+  } satisfies CSSProperties,
+  heading: {
+    fontSize: "18px",
+    fontWeight: 600,
+    margin: "0 0 12px 0",
+    color: "#f0f0f0",
+  } satisfies CSSProperties,
+  subheading: {
+    fontSize: "14px",
+    fontWeight: 600,
+    margin: "0 0 8px 0",
+    color: "#d0d0d0",
+  } satisfies CSSProperties,
+  table: {
+    width: "100%",
+    borderCollapse: "collapse" as const,
+    fontSize: "13px",
+  } satisfies CSSProperties,
+  th: {
+    textAlign: "left" as const,
+    padding: "8px 12px",
+    borderBottom: "1px solid rgba(255,255,255,0.1)",
+    color: "#999",
+    fontWeight: 500,
+    fontSize: "11px",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.5px",
+  } satisfies CSSProperties,
+  td: {
+    padding: "8px 12px",
+    borderBottom: "1px solid rgba(255,255,255,0.05)",
+    verticalAlign: "top" as const,
+  } satisfies CSSProperties,
+  levelBadge: (level: string): CSSProperties => ({
+    display: "inline-block",
+    padding: "2px 6px",
+    borderRadius: "4px",
+    fontSize: "11px",
+    fontWeight: 600,
+    textTransform: "uppercase",
+    background:
+      level === "fatal"
+        ? "rgba(220,38,38,0.2)"
+        : level === "error"
+          ? "rgba(239,68,68,0.15)"
+          : level === "warning"
+            ? "rgba(234,179,8,0.15)"
+            : "rgba(100,100,100,0.15)",
+    color:
+      level === "fatal"
+        ? "#fca5a5"
+        : level === "error"
+          ? "#fca5a5"
+          : level === "warning"
+            ? "#fde047"
+            : "#aaa",
+  }),
+  link: {
+    color: "#60a5fa",
+    textDecoration: "none",
+    cursor: "pointer",
+  } satisfies CSSProperties,
+  muted: {
+    color: "#888",
+    fontSize: "12px",
+  } satisfies CSSProperties,
+  empty: {
+    color: "#666",
+    textAlign: "center" as const,
+    padding: "24px",
+    fontSize: "14px",
+  } satisfies CSSProperties,
+  error: {
+    color: "#fca5a5",
+    background: "rgba(220,38,38,0.1)",
+    borderRadius: "6px",
+    padding: "12px",
+    fontSize: "13px",
+  } satisfies CSSProperties,
+  pre: {
+    background: "rgba(0,0,0,0.3)",
+    borderRadius: "6px",
+    padding: "12px",
+    fontSize: "12px",
+    fontFamily: "monospace",
+    overflowX: "auto" as const,
+    whiteSpace: "pre-wrap" as const,
+    color: "#ccc",
+    maxHeight: "400px",
+    overflow: "auto",
+  } satisfies CSSProperties,
+  btn: {
+    background: "rgba(255,255,255,0.08)",
+    border: "1px solid rgba(255,255,255,0.12)",
+    borderRadius: "6px",
+    color: "#e0e0e0",
+    padding: "6px 12px",
+    cursor: "pointer",
+    fontSize: "13px",
+  } satisfies CSSProperties,
+};
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Issue table (shared between page and widget)
+// ---------------------------------------------------------------------------
+
+function IssueTable({
+  issues,
+  compact,
+  onSelect,
+}: {
+  issues: SentryIssueRow[];
+  compact?: boolean;
+  onSelect?: (id: string) => void;
+}) {
+  if (issues.length === 0) {
+    return <div style={styles.empty}>No unresolved issues found.</div>;
+  }
+  return (
+    <table style={styles.table}>
+      <thead>
+        <tr>
+          <th style={styles.th}>Level</th>
+          <th style={styles.th}>Issue</th>
+          {!compact && <th style={styles.th}>Culprit</th>}
+          <th style={styles.th}>Events</th>
+          {!compact && <th style={styles.th}>Users</th>}
+          <th style={styles.th}>Last Seen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {issues.map((issue) => (
+          <tr key={issue.id}>
+            <td style={styles.td}>
+              <span style={styles.levelBadge(issue.level)}>{issue.level}</span>
+            </td>
+            <td style={styles.td}>
+              {onSelect ? (
+                <span
+                  style={{ ...styles.link, fontWeight: 500 }}
+                  onClick={() => onSelect(issue.id)}
+                >
+                  {issue.shortId}
+                </span>
+              ) : (
+                <a
+                  href={issue.permalink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ ...styles.link, fontWeight: 500 }}
+                >
+                  {issue.shortId}
+                </a>
+              )}
+              <div
+                style={{
+                  color: "#bbb",
+                  fontSize: "12px",
+                  marginTop: "2px",
+                  maxWidth: compact ? "200px" : "400px",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {issue.title}
+              </div>
+            </td>
+            {!compact && (
+              <td style={{ ...styles.td, ...styles.muted }}>{issue.culprit}</td>
+            )}
+            <td style={{ ...styles.td, fontVariantNumeric: "tabular-nums" }}>
+              {issue.count}
+            </td>
+            {!compact && (
+              <td style={{ ...styles.td, fontVariantNumeric: "tabular-nums" }}>
+                {issue.userCount}
+              </td>
+            )}
+            <td style={{ ...styles.td, ...styles.muted }}>
+              {timeAgo(issue.lastSeen)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Issue detail view
+// ---------------------------------------------------------------------------
+
+function IssueDetail({
+  issueId,
+  onBack,
+}: {
+  issueId: string;
+  onBack: () => void;
+}) {
+  const { data, loading, error } = usePluginData<IssueDetailData>(
+    DATA_KEYS.issueDetail,
+    { issueId },
+  );
+
+  return (
+    <div>
+      <div style={{ marginBottom: "12px" }}>
+        <span style={styles.btn} onClick={onBack}>
+          &larr; Back to issues
+        </span>
+      </div>
+      {loading && <div style={styles.muted}>Loading issue detail...</div>}
+      {error && <div style={styles.error}>{error.message}</div>}
+      {data && (
+        <>
+          <div style={styles.card}>
+            <h3 style={styles.heading}>
+              <span style={styles.levelBadge(data.issue.level)}>
+                {data.issue.level}
+              </span>{" "}
+              {data.issue.shortId}: {data.issue.title}
+            </h3>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+                gap: "12px",
+                fontSize: "13px",
+              }}
+            >
+              <div>
+                <span style={styles.muted}>Status</span>
+                <div>{data.issue.status}</div>
+              </div>
+              <div>
+                <span style={styles.muted}>Events</span>
+                <div>{data.issue.count}</div>
+              </div>
+              <div>
+                <span style={styles.muted}>Users</span>
+                <div>{data.issue.userCount}</div>
+              </div>
+              <div>
+                <span style={styles.muted}>First Seen</span>
+                <div>{timeAgo(data.issue.firstSeen)}</div>
+              </div>
+              <div>
+                <span style={styles.muted}>Last Seen</span>
+                <div>{timeAgo(data.issue.lastSeen)}</div>
+              </div>
+              <div>
+                <span style={styles.muted}>Culprit</span>
+                <div>{data.issue.culprit}</div>
+              </div>
+            </div>
+            {data.issue.permalink && (
+              <div style={{ marginTop: "12px" }}>
+                <a
+                  href={data.issue.permalink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={styles.link}
+                >
+                  View in Sentry &rarr;
+                </a>
+              </div>
+            )}
+          </div>
+
+          {data.stacktrace && (
+            <div style={styles.card}>
+              <h4 style={styles.subheading}>Stacktrace</h4>
+              <pre style={styles.pre}>
+                {JSON.stringify(data.stacktrace, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {data.breadcrumbs && (
+            <div style={styles.card}>
+              <h4 style={styles.subheading}>Breadcrumbs</h4>
+              <pre style={styles.pre}>
+                {JSON.stringify(data.breadcrumbs, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {data.latestEvent && (
+            <div style={styles.card}>
+              <h4 style={styles.subheading}>Latest Event</h4>
+              <div style={{ fontSize: "13px", marginBottom: "8px" }}>
+                <span style={styles.muted}>Event ID:</span>{" "}
+                {data.latestEvent.eventID}
+              </div>
+              <div style={{ fontSize: "13px", marginBottom: "8px" }}>
+                <span style={styles.muted}>Date:</span>{" "}
+                {data.latestEvent.dateCreated}
+              </div>
+              {data.latestEvent.message && (
+                <div style={{ fontSize: "13px", marginBottom: "8px" }}>
+                  <span style={styles.muted}>Message:</span>{" "}
+                  {data.latestEvent.message}
+                </div>
+              )}
+              {data.latestEvent.tags && data.latestEvent.tags.length > 0 && (
+                <div>
+                  <span style={styles.muted}>Tags:</span>
+                  <div
+                    style={{
+                      display: "flex",
+                      flexWrap: "wrap",
+                      gap: "4px",
+                      marginTop: "4px",
+                    }}
+                  >
+                    {data.latestEvent.tags.map((tag, i) => (
+                      <span
+                        key={i}
+                        style={{
+                          background: "rgba(255,255,255,0.06)",
+                          borderRadius: "4px",
+                          padding: "2px 6px",
+                          fontSize: "11px",
+                          color: "#aaa",
+                        }}
+                      >
+                        {tag.key}={tag.value}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {data.events.length > 1 && (
+            <div style={styles.card}>
+              <h4 style={styles.subheading}>
+                Recent Events ({data.events.length})
+              </h4>
+              <table style={styles.table}>
+                <thead>
+                  <tr>
+                    <th style={styles.th}>Event ID</th>
+                    <th style={styles.th}>Title</th>
+                    <th style={styles.th}>Date</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.events.map((evt) => (
+                    <tr key={evt.eventID}>
+                      <td style={{ ...styles.td, ...styles.muted, fontFamily: "monospace" }}>
+                        {evt.eventID.slice(0, 12)}...
+                      </td>
+                      <td style={styles.td}>{evt.title}</td>
+                      <td style={{ ...styles.td, ...styles.muted }}>
+                        {timeAgo(evt.dateCreated)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exports: Page
+// ---------------------------------------------------------------------------
+
+export function SentryPage(_props: PluginPageProps) {
+  const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
+  const { data, loading, error } = usePluginData<OverviewData>(
+    DATA_KEYS.overview,
+    {},
+  );
+
+  if (selectedIssueId) {
+    return (
+      <div style={styles.container}>
+        <IssueDetail
+          issueId={selectedIssueId}
+          onBack={() => setSelectedIssueId(null)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.container}>
+      <h2 style={styles.heading}>Sentry Errors</h2>
+      {loading && <div style={styles.muted}>Loading...</div>}
+      {error && <div style={styles.error}>{error.message}</div>}
+      {data && !data.configured && (
+        <div style={styles.card}>
+          <p style={{ color: "#fde047", margin: 0 }}>
+            Sentry is not configured. Set the auth token and organization slug
+            in plugin settings.
+          </p>
+        </div>
+      )}
+      {data?.error && <div style={styles.error}>{data.error}</div>}
+      {data?.configured && (
+        <div style={styles.card}>
+          <h3 style={styles.subheading}>
+            Unresolved Issues ({data.issues.length})
+          </h3>
+          <IssueTable issues={data.issues} onSelect={setSelectedIssueId} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exports: Dashboard Widget
+// ---------------------------------------------------------------------------
+
+export function SentryDashboardWidget(_props: PluginWidgetProps) {
+  const { data, loading, error } = usePluginData<OverviewData>(
+    DATA_KEYS.overview,
+    {},
+  );
+
+  const issues = data?.issues?.slice(0, 5) ?? [];
+
+  return (
+    <div style={styles.container}>
+      <h3 style={styles.subheading}>Sentry Errors</h3>
+      {loading && <div style={styles.muted}>Loading...</div>}
+      {error && (
+        <div style={{ ...styles.error, fontSize: "12px" }}>
+          {error.message}
+        </div>
+      )}
+      {data && !data.configured && (
+        <div style={{ ...styles.muted, fontSize: "12px" }}>
+          Not configured — set up in plugin settings.
+        </div>
+      )}
+      {data?.error && (
+        <div style={{ ...styles.error, fontSize: "12px" }}>{data.error}</div>
+      )}
+      {data?.configured && issues.length === 0 && (
+        <div style={styles.muted}>No unresolved issues</div>
+      )}
+      {data?.configured && issues.length > 0 && (
+        <IssueTable issues={issues} compact />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exports: Settings Page
+// ---------------------------------------------------------------------------
+
+export function SentrySettingsPage(_props: PluginSettingsPageProps) {
+  const ctx = useHostContext();
+  return (
+    <div style={styles.container}>
+      <h2 style={styles.heading}>Sentry Plugin Settings</h2>
+      <div style={styles.card}>
+        <p style={{ fontSize: "13px", color: "#bbb", margin: 0 }}>
+          Configure this plugin via the plugin configuration panel. Set
+          the following values:
+        </p>
+        <ul
+          style={{
+            fontSize: "13px",
+            color: "#bbb",
+            paddingLeft: "20px",
+            marginTop: "8px",
+          }}
+        >
+          <li>
+            <strong>Auth Token</strong> — Sentry API token with{" "}
+            <code>org:read</code>, <code>project:read</code>,{" "}
+            <code>event:read</code> scopes
+          </li>
+          <li>
+            <strong>Organization Slug</strong> — Your Sentry org slug
+          </li>
+          <li>
+            <strong>Project Slug</strong> — Optional, filters to a specific
+            project
+          </li>
+          <li>
+            <strong>Sentry Base URL</strong> — For self-hosted instances
+            (defaults to https://sentry.io)
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exports: Sidebar Link
+// ---------------------------------------------------------------------------
+
+export function SentrySidebarLink(_props: PluginSidebarProps) {
+  const ctx = useHostContext();
+  const prefix = ctx.companyPrefix ?? "";
+  return (
+    <a
+      href={`/${prefix}/plugins/${PLUGIN_ID}/${PAGE_ROUTE}`}
+      style={{
+        ...styles.link,
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "6px 0",
+        fontSize: "13px",
+      }}
+    >
+      Sentry Errors
+    </a>
+  );
+}

--- a/packages/plugins/plugin-sentry/src/worker.ts
+++ b/packages/plugins/plugin-sentry/src/worker.ts
@@ -1,0 +1,438 @@
+import {
+  definePlugin,
+  runWorker,
+  type PaperclipPlugin,
+  type PluginContext,
+  type PluginHealthDiagnostics,
+  type ToolResult,
+} from "@paperclipai/plugin-sdk";
+import {
+  DATA_KEYS,
+  DEFAULT_CONFIG,
+  PLUGIN_ID,
+  TOOL_NAMES,
+} from "./constants.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SentryConfig = {
+  authToken: string;
+  organizationSlug: string;
+  projectSlug?: string;
+  sentryBaseUrl?: string;
+};
+
+type SentryIssue = {
+  id: string;
+  shortId: string;
+  title: string;
+  culprit: string;
+  level: string;
+  status: string;
+  firstSeen: string;
+  lastSeen: string;
+  count: string;
+  userCount: number;
+  project: { id: string; name: string; slug: string };
+  metadata: Record<string, unknown>;
+  permalink: string;
+  statusDetails: Record<string, unknown>;
+};
+
+type SentryEvent = {
+  eventID: string;
+  title: string;
+  message: string;
+  dateCreated: string;
+  context: Record<string, unknown>;
+  tags: Array<{ key: string; value: string }>;
+  entries: Array<{ type: string; data: unknown }>;
+};
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+let currentContext: PluginContext | null = null;
+
+async function getConfig(ctx: PluginContext): Promise<SentryConfig> {
+  const raw = (await ctx.config.get()) as Partial<SentryConfig> | null;
+  return {
+    authToken: raw?.authToken ?? DEFAULT_CONFIG.authToken,
+    organizationSlug: raw?.organizationSlug ?? DEFAULT_CONFIG.organizationSlug,
+    projectSlug: raw?.projectSlug ?? DEFAULT_CONFIG.projectSlug,
+    sentryBaseUrl: raw?.sentryBaseUrl ?? DEFAULT_CONFIG.sentryBaseUrl,
+  };
+}
+
+function ensureConfigured(config: SentryConfig): void {
+  if (!config.authToken) {
+    throw new Error("Sentry auth token is not configured. Set it in plugin settings.");
+  }
+  if (!config.organizationSlug) {
+    throw new Error("Sentry organization slug is not configured. Set it in plugin settings.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sentry API helpers
+// ---------------------------------------------------------------------------
+
+async function sentryFetch(
+  ctx: PluginContext,
+  config: SentryConfig,
+  path: string,
+): Promise<unknown> {
+  const baseUrl = (config.sentryBaseUrl || "https://sentry.io").replace(/\/$/, "");
+  const url = `${baseUrl}/api/0/${path}`;
+
+  const response = await ctx.http.fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${config.authToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Sentry API ${response.status}: ${body.slice(0, 500)}`);
+  }
+
+  return await response.json();
+}
+
+function buildIssueQuery(
+  config: SentryConfig,
+  opts: {
+    query?: string;
+    project?: string;
+    limit?: number;
+    sort?: string;
+  },
+): string {
+  const org = config.organizationSlug;
+  const params = new URLSearchParams();
+  if (opts.query) params.set("query", opts.query);
+  const limit = Math.min(Math.max(opts.limit ?? 25, 1), 100);
+  params.set("limit", String(limit));
+  if (opts.sort) params.set("sort", opts.sort);
+
+  const projectSlug = opts.project ?? config.projectSlug;
+  if (projectSlug) params.set("project", projectSlug);
+
+  return `organizations/${org}/issues/?${params.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Tool handlers
+// ---------------------------------------------------------------------------
+
+async function registerToolHandlers(ctx: PluginContext): Promise<void> {
+  ctx.tools.register(
+    TOOL_NAMES.listIssues,
+    {
+      displayName: "List Sentry Issues",
+      description: "List recent Sentry issues filtered by project, level, and status.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          project: { type: "string" },
+          limit: { type: "number" },
+          sort: { type: "string", enum: ["date", "new", "freq", "priority"] },
+        },
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const config = await getConfig(ctx);
+      ensureConfigured(config);
+      const p = params as { query?: string; project?: string; limit?: number; sort?: string };
+      const path = buildIssueQuery(config, p);
+      const issues = (await sentryFetch(ctx, config, path)) as SentryIssue[];
+      const summary = issues.map((i) => ({
+        id: i.id,
+        shortId: i.shortId,
+        title: i.title,
+        level: i.level,
+        status: i.status,
+        count: i.count,
+        userCount: i.userCount,
+        lastSeen: i.lastSeen,
+        firstSeen: i.firstSeen,
+        culprit: i.culprit,
+        project: i.project?.slug,
+        permalink: i.permalink,
+      }));
+      return {
+        content: `Found ${issues.length} Sentry issue(s).\n\n${summary.map((i) => `- [${i.level.toUpperCase()}] ${i.shortId}: ${i.title} (${i.count} events, last seen ${i.lastSeen})`).join("\n")}`,
+        data: summary,
+      };
+    },
+  );
+
+  ctx.tools.register(
+    TOOL_NAMES.getIssue,
+    {
+      displayName: "Get Sentry Issue Detail",
+      description: "Get detailed information about a Sentry issue including stacktrace and tags.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          issueId: { type: "string" },
+        },
+        required: ["issueId"],
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const config = await getConfig(ctx);
+      ensureConfigured(config);
+      const { issueId } = params as { issueId: string };
+      if (!issueId) return { error: "issueId is required" };
+
+      const issue = (await sentryFetch(ctx, config, `issues/${issueId}/`)) as SentryIssue;
+      const events = (await sentryFetch(ctx, config, `issues/${issueId}/events/?limit=5`)) as SentryEvent[];
+      const latestEvent = events[0];
+
+      // Extract stacktrace from latest event entries
+      let stacktrace: unknown = null;
+      if (latestEvent?.entries) {
+        const exceptionEntry = latestEvent.entries.find((e) => e.type === "exception");
+        if (exceptionEntry) stacktrace = exceptionEntry.data;
+      }
+
+      return {
+        content: `**${issue.shortId}: ${issue.title}**\nLevel: ${issue.level} | Status: ${issue.status}\nFirst seen: ${issue.firstSeen} | Last seen: ${issue.lastSeen}\nEvents: ${issue.count} | Users: ${issue.userCount}\nCulprit: ${issue.culprit}\n${stacktrace ? "\nStacktrace available in data." : ""}`,
+        data: {
+          issue: {
+            id: issue.id,
+            shortId: issue.shortId,
+            title: issue.title,
+            level: issue.level,
+            status: issue.status,
+            culprit: issue.culprit,
+            firstSeen: issue.firstSeen,
+            lastSeen: issue.lastSeen,
+            count: issue.count,
+            userCount: issue.userCount,
+            metadata: issue.metadata,
+            permalink: issue.permalink,
+          },
+          latestEvent: latestEvent
+            ? {
+                eventID: latestEvent.eventID,
+                title: latestEvent.title,
+                message: latestEvent.message,
+                dateCreated: latestEvent.dateCreated,
+                tags: latestEvent.tags,
+              }
+            : null,
+          stacktrace,
+          recentEvents: events.map((e) => ({
+            eventID: e.eventID,
+            title: e.title,
+            dateCreated: e.dateCreated,
+          })),
+        },
+      };
+    },
+  );
+
+  ctx.tools.register(
+    TOOL_NAMES.search,
+    {
+      displayName: "Search Sentry Errors",
+      description: "Search Sentry errors by query string.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          level: { type: "string", enum: ["fatal", "error", "warning", "info", "debug"] },
+          dateRange: { type: "string" },
+          limit: { type: "number" },
+        },
+        required: ["query"],
+      },
+    },
+    async (params): Promise<ToolResult> => {
+      const config = await getConfig(ctx);
+      ensureConfigured(config);
+      const p = params as { query: string; level?: string; dateRange?: string; limit?: number };
+
+      // Build a combined search query for the issues endpoint
+      let sentryQuery = p.query;
+      if (p.level) sentryQuery += ` level:${p.level}`;
+
+      const org = config.organizationSlug;
+      const urlParams = new URLSearchParams();
+      urlParams.set("query", sentryQuery);
+      const limit = Math.min(Math.max(p.limit ?? 25, 1), 100);
+      urlParams.set("limit", String(limit));
+
+      // Map dateRange to Sentry statsPeriod
+      if (p.dateRange) {
+        urlParams.set("statsPeriod", p.dateRange);
+      }
+      if (config.projectSlug) {
+        urlParams.set("project", config.projectSlug);
+      }
+
+      const issues = (await sentryFetch(
+        ctx,
+        config,
+        `organizations/${org}/issues/?${urlParams.toString()}`,
+      )) as SentryIssue[];
+
+      const results = issues.map((i) => ({
+        id: i.id,
+        shortId: i.shortId,
+        title: i.title,
+        level: i.level,
+        status: i.status,
+        count: i.count,
+        lastSeen: i.lastSeen,
+        culprit: i.culprit,
+        permalink: i.permalink,
+      }));
+
+      return {
+        content: `Search for "${p.query}" returned ${results.length} result(s).\n\n${results.map((r) => `- [${r.level.toUpperCase()}] ${r.shortId}: ${r.title} (${r.count} events)`).join("\n")}`,
+        data: results,
+      };
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Data handlers (for UI bridge)
+// ---------------------------------------------------------------------------
+
+async function registerDataHandlers(ctx: PluginContext): Promise<void> {
+  ctx.data.register(DATA_KEYS.overview, async () => {
+    const config = await getConfig(ctx);
+    if (!config.authToken || !config.organizationSlug) {
+      return {
+        configured: false,
+        issues: [],
+        stats: null,
+      };
+    }
+    try {
+      const org = config.organizationSlug;
+      const params = new URLSearchParams();
+      params.set("query", "is:unresolved");
+      params.set("limit", "20");
+      params.set("sort", "date");
+      if (config.projectSlug) params.set("project", config.projectSlug);
+
+      const issues = (await sentryFetch(
+        ctx,
+        config,
+        `organizations/${org}/issues/?${params.toString()}`,
+      )) as SentryIssue[];
+
+      return {
+        configured: true,
+        issues: issues.map((i) => ({
+          id: i.id,
+          shortId: i.shortId,
+          title: i.title,
+          level: i.level,
+          status: i.status,
+          count: i.count,
+          userCount: i.userCount,
+          lastSeen: i.lastSeen,
+          firstSeen: i.firstSeen,
+          culprit: i.culprit,
+          project: i.project?.slug ?? "",
+          permalink: i.permalink,
+        })),
+      };
+    } catch (err) {
+      return {
+        configured: true,
+        issues: [],
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  });
+
+  ctx.data.register(DATA_KEYS.issueDetail, async (params) => {
+    const config = await getConfig(ctx);
+    ensureConfigured(config);
+    const issueId = typeof params.issueId === "string" ? params.issueId : "";
+    if (!issueId) throw new Error("issueId is required");
+
+    const issue = (await sentryFetch(ctx, config, `issues/${issueId}/`)) as SentryIssue;
+    const events = (await sentryFetch(ctx, config, `issues/${issueId}/events/?limit=10`)) as SentryEvent[];
+    const latestEvent = events[0];
+
+    let stacktrace: unknown = null;
+    let breadcrumbs: unknown = null;
+    if (latestEvent?.entries) {
+      const exceptionEntry = latestEvent.entries.find((e) => e.type === "exception");
+      if (exceptionEntry) stacktrace = exceptionEntry.data;
+      const breadcrumbEntry = latestEvent.entries.find((e) => e.type === "breadcrumbs");
+      if (breadcrumbEntry) breadcrumbs = breadcrumbEntry.data;
+    }
+
+    return {
+      issue,
+      latestEvent: latestEvent ?? null,
+      stacktrace,
+      breadcrumbs,
+      events: events.map((e) => ({
+        eventID: e.eventID,
+        title: e.title,
+        message: e.message,
+        dateCreated: e.dateCreated,
+        tags: e.tags,
+      })),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Plugin definition
+// ---------------------------------------------------------------------------
+
+const plugin: PaperclipPlugin = definePlugin({
+  async setup(ctx) {
+    currentContext = ctx;
+    ctx.logger.info("Sentry plugin initializing", { pluginId: PLUGIN_ID });
+    await registerToolHandlers(ctx);
+    await registerDataHandlers(ctx);
+    ctx.logger.info("Sentry plugin setup complete");
+  },
+
+  async onHealth(): Promise<PluginHealthDiagnostics> {
+    const ctx = currentContext;
+    if (!ctx) {
+      return { status: "degraded", message: "Plugin context not initialized" };
+    }
+    try {
+      const config = await getConfig(ctx);
+      if (!config.authToken || !config.organizationSlug) {
+        return { status: "degraded", message: "Sentry credentials not configured" };
+      }
+      // Quick connectivity check
+      await sentryFetch(ctx, config, `organizations/${config.organizationSlug}/`);
+      return { status: "ok", message: "Connected to Sentry" };
+    } catch (err) {
+      return {
+        status: "degraded",
+        message: `Sentry API unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  },
+
+  async onValidateConfig(config) {
+    const c = config as Partial<SentryConfig>;
+    if (!c.authToken) return { ok: false, errors: ["authToken is required"] };
+    if (!c.organizationSlug) return { ok: false, errors: ["organizationSlug is required"] };
+    return { ok: true };
+  },
+});
+
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/plugin-sentry/tsconfig.json
+++ b/packages/plugins/plugin-sentry/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,71 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/plugins/plugin-obsidian:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
+  packages/plugins/plugin-sentry:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+
   packages/plugins/sdk:
     dependencies:
       '@paperclipai/shared':


### PR DESCRIPTION
## Summary

- Adds `@paperclipai/plugin-sentry` — a full Sentry integration plugin
- **Agent Tools**: `sentry.list-issues`, `sentry.get-issue`, `sentry.search` for autonomous error diagnostics by agents
- **UI**: Dashboard widget (top 5 unresolved errors), full error page with stacktrace/breadcrumbs/events detail, sidebar link, and settings page
- **Config**: Sentry auth token, organization slug, project slug, base URL (self-hosted support)

## Test plan

- [ ] Install plugin and configure with valid Sentry credentials
- [ ] Verify dashboard widget loads unresolved issues
- [ ] Verify full error page shows issue list and detail drill-down with stacktrace
- [ ] Test agent tools via plugin tool execution endpoint
- [ ] Verify settings page displays configuration instructions
- [ ] Confirm plugin health check reports connectivity status

🤖 Generated with [Claude Code](https://claude.com/claude-code)