### PR TITLE
fix: exclude Paperclip API calls from RTK rewrite

### DIFF
--- a/tools/rtk/rtk-rewrite.sh
+++ b/tools/rtk/rtk-rewrite.sh
@@ -29,6 +29,11 @@ if [ -z "$CMD" ]; then
   exit 0
 fi
 
+# Skip RTK for Paperclip API calls — agents need raw JSON responses
+if echo "$CMD" | grep -qE 'curl.*(localhost:3100|\$PAPERCLIP_API_URL|\$\{PAPERCLIP_API_URL)'; then
+  exit 0
+fi
+
 # Delegate rewrite logic to rtk binary
 REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || exit 0
 


### PR DESCRIPTION
## Summary

- Adds early exit in `tools/rtk/rtk-rewrite.sh` for `curl` commands targeting Paperclip API (`localhost:3100` or `$PAPERCLIP_API_URL`)
- RTK remains active for all other bash commands (ls, find, grep, cat, etc.)
- Fixes agents receiving type placeholders instead of real JSON from API calls

Closes https://github.com/JavierCervilla/paperclip/issues/51

## Test plan

- [ ] Verify `curl` to Paperclip API returns raw JSON (not RTK placeholders)
- [ ] Verify RTK still rewrites non-API commands (e.g. `ls`, `find`)
- [ ] Run an agent heartbeat end-to-end without workarounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)