### PR TITLE
fix: only mark core paperclip skill as required

### DIFF
--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2020,14 +2020,14 @@ export function companySkillService(db: Db) {
       }
       if (!source) continue;
 
-      const required = sourceKind === "paperclip_bundled";
+      const required = skill.key === "paperclipai/paperclip/paperclip";
       out.push({
         key: skill.key,
         runtimeName: buildSkillRuntimeName(skill.key, skill.slug),
         source,
         required,
         requiredReason: required
-          ? "Bundled Paperclip skills are always available for local adapters."
+          ? "Core Paperclip skill is always loaded for local adapters."
           : null,
       });
     }


### PR DESCRIPTION
## Summary

- Changed `company-skills.ts` so only `paperclipai/paperclip/paperclip` is `required: true`
- Other bundled skills (`paperclip-create-agent`, `paperclip-create-plugin`, `para-memory-files`) are now optional — available but not force-loaded
- Saves ~4K tokens/run for IC agents that specify explicit `desiredSkills`

## Test plan

- [x] `pnpm -r typecheck` passes
- [x] `company-skills.test.ts` — 11/11 pass
- [x] `company-skills-routes.test.ts` — 3/3 pass
- [ ] Verify `GET /api/agents/:id/skills` shows `required: false` for non-core bundled skills
- [ ] Verify agent with `desiredSkills: ["paperclipai/paperclip/paperclip"]` only mounts that skill

Closes PAP-153

🤖 Generated with [Claude Code](https://claude.com/claude-code)