### PR TITLE
fix(ops): repair agents stuck in pending_approval from prior broken imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:generate": "pnpm --filter @paperclipai/db generate",
     "db:migrate": "pnpm --filter @paperclipai/db migrate",
     "secrets:migrate-inline-env": "tsx scripts/migrate-inline-env-secrets.ts",
+    "repair:stuck-import-agents": "tsx scripts/repair-stuck-import-agents.ts",
     "db:backup": "./scripts/backup-db.sh",
     "paperclipai": "node cli/node_modules/tsx/dist/cli.mjs cli/src/index.ts",
     "build:npm": "./scripts/build-npm.sh",

--- a/scripts/repair-stuck-import-agents.ts
+++ b/scripts/repair-stuck-import-agents.ts
@@ -1,0 +1,64 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { agents, approvals, createDb } from "@paperclipai/db";
+
+async function main() {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+
+  const apply = process.argv.includes("--apply");
+  const db = createDb(dbUrl);
+
+  const pending = await db.select().from(agents).where(eq(agents.status, "pending_approval"));
+
+  if (pending.length === 0) {
+    console.log("No agents in pending_approval. Nothing to repair.");
+    process.exit(0);
+  }
+
+  const openHireApprovals = await db
+    .select({ payload: approvals.payload })
+    .from(approvals)
+    .where(
+      and(eq(approvals.type, "hire_agent"), inArray(approvals.status, ["pending", "revision_requested"])),
+    );
+
+  const legitimatelyPending = new Set<string>();
+  for (const row of openHireApprovals) {
+    const agentId = (row.payload as Record<string, unknown> | null)?.agentId;
+    if (typeof agentId === "string") legitimatelyPending.add(agentId);
+  }
+
+  const stuck = pending.filter((agent) => !legitimatelyPending.has(agent.id));
+
+  console.log(`Found ${pending.length} agents with status='pending_approval'`);
+  console.log(`  ${legitimatelyPending.size} have an open hire_agent approval (kept).`);
+  console.log(`  ${stuck.length} are stuck with no open hire approval (would be flipped to idle).`);
+
+  for (const agent of stuck) {
+    console.log(`  - ${agent.id}  company=${agent.companyId}  role=${agent.role}  name=${agent.name}`);
+  }
+
+  if (!apply) {
+    console.log("\nDry run. Re-run with --apply to persist changes.");
+    process.exit(0);
+  }
+
+  if (stuck.length === 0) {
+    process.exit(0);
+  }
+
+  const ids = stuck.map((a) => a.id);
+  const result = await db
+    .update(agents)
+    .set({ status: "idle", updatedAt: new Date() })
+    .where(and(eq(agents.status, "pending_approval"), sql`${agents.id} = ANY(${ids})`))
+    .returning({ id: agents.id });
+
+  console.log(`\nFlipped ${result.length} agent(s) to status='idle'.`);
+  process.exit(0);
+}
+
+void main();


### PR DESCRIPTION
## Summary

Follow-up to [PAP-851](/PAP/issues/PAP-851). Adds a one-shot admin repair for the agents that ended up in `status = 'pending_approval'` with no matching open `hire_agent` approval, so they remain unreachable and un-invokable until repaired.

## Safety predicate

An agent is flipped to `idle` iff:

- `agents.status = 'pending_approval'`
- **AND** no row in `approvals` has `type = 'hire_agent'` with status in (`pending`, `revision_requested`) and `payload.agentId` matching the agent id.

Rejected hires already terminate the agent in `approvals.service.ts`, so they don't reach this check. Agents with a legitimately open hire (pending OR revision-requested) are preserved.

## Changes

- `scripts/repair-stuck-import-agents.ts` — new, modelled on `scripts/migrate-inline-env-secrets.ts`. Dry-run by default, `--apply` to persist. Uses drizzle via `@paperclipai/db` with `DATABASE_URL`.
- `package.json` — adds the `repair:stuck-import-agents` script.

## How to run (preview -> prod)

On each deployed environment, with `DATABASE_URL` pointing at that env's DB:

\`\`\`sh
pnpm repair:stuck-import-agents          # dry run — prints counts + per-agent info
pnpm repair:stuck-import-agents --apply  # persist
\`\`\`

Run preview first, sanity check the dry-run output, then \`--apply\` there. Repeat on prod.

## Test plan

- [x] \`pnpm -r typecheck\` — clean
- [ ] Dry-run on preview DB — verify printed counts match expected stuck agents
- [ ] \`--apply\` on preview — confirm flipped agents become invokable
- [ ] Repeat dry-run on prod
- [ ] \`--apply\` on prod

Closes [PAP-852](/PAP/issues/PAP-852).