### PR TITLE
docs(safety): recover safety conventions reference (PAP-803)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,18 @@ When creating a pull request (via `gh pr create` or any other method), you **mus
 - **Model Used** — the AI model that produced or assisted with the change (provider, exact model ID, context window, capabilities). Write "None — human-authored" if no AI was used.
 - **Checklist** — all items checked
 
-## 11. Definition of Done
+## 11. Safety Conventions
+
+Agents MUST follow the safety conventions documented in `skills/paperclip/references/safety-conventions.md`. Key rules:
+
+- **Dry-run first:** preview destructive CLI commands before executing; block on approval if no preview is available.
+- **No force-push without board approval.** No `git reset --hard`, `git clean -f`, or `git restore .` without confirming no unrecorded work is at risk.
+- **No `rm -rf` without verification.** Confirm the path and get explicit acknowledgement before deleting shared or persistent data.
+- **Sandbox awareness:** writes to mounted volumes and external API calls (GitHub, LLM providers, DB) affect real systems — treat them as production actions.
+
+When any of these rules require approval, set the issue to `blocked`, post a comment describing the exact action and why, and wait for explicit confirmation.
+
+## 12. Definition of Done
 
 A change is done when all are true:
 
@@ -202,7 +213,16 @@ A change is done when all are true:
 4. Docs updated when behavior or commands change
 5. PR description follows the [PR template](.github/PULL_REQUEST_TEMPLATE.md) with all sections filled in (including Model Used)
 
-## 11. Fork-Specific: HenkDz/paperclip
+## 13. Agentic Engineering References
+
+Guides for agent collaboration patterns used in this repo:
+
+- **3-agent swarm pattern** (Architect/Planner/Implementer/Verifier): `skills/paperclip/references/swarm-pattern.md`
+- **Verifier workflow and Fix Forward**: `skills/paperclip/references/verifier-workflow.md`
+- **Paperclip API reference**: `skills/paperclip/references/api-reference.md`
+- **Company skills management**: `skills/paperclip/references/company-skills.md`
+
+## 14. Fork-Specific: HenkDz/paperclip
 
 This is a fork of `paperclipai/paperclip` with QoL patches and an **external-only** Hermes adapter story on branch `feat/externalize-hermes-adapter` ([tree](https://github.com/HenkDz/paperclip/tree/feat/externalize-hermes-adapter)).
 

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -58,10 +58,19 @@ Testable, objective conditions that confirm the task is complete. Each criterion
 
 **Rule:** No agent should start coding on a task with priority >= medium unless all three fields are present in the issue description or a linked plan document. Reject or send back any task missing these fields.
 
-## Safety Considerations
+## Safety Conventions
 
-- Never exfiltrate secrets or private data.
-- Do not perform any destructive commands unless explicitly requested by the board.
+You MUST follow safe operation practices at all times:
+
+- **Dry-run first.** Before executing any destructive CLI command, use `--dry-run`, `--preview`, or `--check` flags if available. If no preview is possible, post your intent on the issue, set status to `blocked`, and wait for approval.
+- **No force-push.** Never run `git push --force` or `git push --force-with-lease` without explicit board approval.
+- **No hard-reset without confirmation.** Never run `git reset --hard`, `git restore .`, or `git clean -f` without first confirming no unrecorded work is at risk.
+- **No `rm -rf` without verification.** Always confirm the exact path and get explicit acknowledgement before deleting shared or persistent data.
+- **Never exfiltrate secrets or private data.**
+- **No destructive commands without board approval.** When in doubt, block and escalate.
+- **Sandbox awareness.** Docker containers isolate the local file system, but writes to mounted volumes and external API calls affect real systems. Treat them as production actions.
+
+Full details: `skills/paperclip/references/safety-conventions.md`
 
 ## References
 

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -2,6 +2,18 @@ You are an agent at Paperclip company.
 
 Keep the work moving until it's done. If you need QA to review it, ask them. If you need your boss to review it, ask them. If someone needs to unblock you, assign them the ticket with a comment asking for what you need. Don't let work just sit here. You must always update your task with a comment.
 
+## Safety Conventions
+
+You MUST follow safe operation practices at all times:
+
+- **Dry-run first.** Before executing any destructive CLI command, use `--dry-run`, `--preview`, or `--check` flags if available. If no preview is possible, post your intent on the issue, set status to `blocked`, and wait for approval.
+- **No force-push.** Never run `git push --force` or `git push --force-with-lease` without explicit board approval.
+- **No hard-reset without confirmation.** Never run `git reset --hard`, `git restore .`, or `git clean -f` without first confirming no unrecorded work is at risk.
+- **No `rm -rf` without verification.** Always confirm the exact path and get explicit acknowledgement before deleting shared or persistent data.
+- **Sandbox awareness.** Docker containers isolate the local file system, but writes to mounted volumes and external API calls (GitHub, LLM providers, DBs) affect real systems. Treat them as production actions.
+
+Full details: `skills/paperclip/references/safety-conventions.md`
+
 ## Task Specification Requirements
 
 For every non-trivial task (priority `medium`, `high`, or `critical`), three fields MUST be present in the issue before you write a single line of code:

--- a/skills/paperclip/references/safety-conventions.md
+++ b/skills/paperclip/references/safety-conventions.md
@@ -1,0 +1,148 @@
+# Safety Conventions for Agentic Work
+
+These conventions govern how agents handle destructive operations, file system mutations, and sandboxed environments. All agents working in Paperclip MUST follow these rules.
+
+---
+
+## 1. Dry-Run First Principle
+
+Before executing any CLI command that mutates shared state, **prefer a dry-run or preview pass** when the tool supports it.
+
+**When to dry-run:**
+
+- Database migrations (`pnpm db:migrate` → inspect generated SQL first)
+- Package installs with side-effects (`npm install --dry-run`)
+- Deployments or release scripts that offer a preview mode
+- Any command that deletes, overwrites, or irreversibly transforms data
+
+**How to dry-run:**
+
+Check the tool's help output for flags like `--dry-run`, `--preview`, `--check`, or `-n`. If the command has no dry-run mode, run the command against a non-production target (e.g., a staging environment or local DB) before running against production.
+
+**Rule:** If a command cannot be previewed or reversed, post a comment to the issue describing the exact command and expected effect, set the issue to `blocked`, and wait for board or manager approval before executing.
+
+---
+
+## 2. Git Safety Rules
+
+### Force-push is forbidden without explicit board approval
+
+Never run:
+
+```sh
+git push --force
+git push --force-with-lease   # also forbidden without approval
+```
+
+Force-pushing rewrites shared history and can destroy teammates' work. If you believe a force-push is truly required, post a comment describing why, set the issue to `blocked`, and wait for explicit board confirmation before proceeding.
+
+### Hard-reset requires confirmation
+
+Never run these without a comment + explicit approval:
+
+```sh
+git reset --hard
+git checkout -- .
+git restore .
+git clean -f
+git clean -fd
+```
+
+These discard local changes permanently. Before running, confirm that the working tree contains no unrecorded work (check `git status` and `git stash list`). Post your intent as a comment on the issue and wait for a reply if the state is ambiguous.
+
+### Safe alternatives to prefer
+
+| Dangerous                 | Safer alternative                                  |
+| ------------------------- | -------------------------------------------------- |
+| `git reset --hard HEAD~1` | `git revert HEAD` (creates undo commit)            |
+| `git push --force`        | Fix the branch structure without rewriting history |
+| `git clean -fd`           | `git clean -n` first to preview, then proceed      |
+
+### Commit hygiene
+
+- Never skip pre-commit hooks (`--no-verify`).
+- Always include `Co-Authored-By: Paperclip <noreply@paperclip.ing>` in commit messages.
+- Never amend published commits (i.e., commits already pushed to remote).
+
+---
+
+## 3. File System Safety
+
+### No recursive deletes without confirmation
+
+Never run:
+
+```sh
+rm -rf <path>
+rm -r <path>
+```
+
+without first:
+
+1. Verifying the path is what you intend (run `ls <path>` or `echo <path>` first).
+2. Confirming there is no untracked or unrecorded work in that directory.
+3. Posting your intent to the issue and receiving explicit acknowledgement when the delete affects shared or persistent data.
+
+**Exceptions:** Deleting build artifacts (`dist/`, `node_modules/`, `.next/`) or explicitly listed temp directories is safe and does not require approval, provided you confirm the path is correct before running.
+
+### Overwriting files
+
+Prefer creating a backup or using version control before overwriting files that cannot be recovered from git history (e.g., data files outside the repo, log archives, DB snapshots).
+
+### Symlinks and path traversal
+
+Never create symlinks that escape the project root or point to system paths (`/etc`, `/var`, `/proc`). Validate any path constructed from user input or external data before using it in file operations.
+
+---
+
+## 4. Sandbox Awareness (Docker)
+
+Agents running inside Docker containers have a partially isolated environment. Understanding what IS and IS NOT isolated prevents accidental side effects.
+
+### What IS isolated (safe to mutate freely)
+
+| Resource                           | Notes                                                                                                                 |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Container file system              | Changes are scoped to the container; they do not persist across container restarts unless written to a mounted volume |
+| In-memory state                    | Process memory, env vars, open file descriptors                                                                       |
+| Localhost ports (within container) | Ports opened inside the container are not exposed to the host unless mapped in `docker-compose.yml`                   |
+| PGlite embedded DB (dev)           | Lives in `data/pglite/` inside the container; reset by deleting that directory                                        |
+
+### What is NOT isolated (can affect the host or shared systems)
+
+| Resource                               | Risk                                                                                                   |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Mounted volumes (`-v` bind mounts)     | Writes to mounted paths affect the host file system directly                                           |
+| Shared DB service on `dokploy-network` | The production Postgres instance is shared; destructive queries affect all users                       |
+| GitHub API calls (`gh` CLI)            | PR comments, merges, and pushes are permanent and visible to all                                       |
+| External HTTP calls                    | Any outbound API call (LLM providers, webhooks, notification services) executes against real endpoints |
+| Environment secrets                    | API keys and tokens injected via env vars are live credentials; treat them as production secrets       |
+
+### Container restart behavior
+
+When the container restarts, the file system resets to the image state **except for bind-mounted directories**. Do not rely on in-container state surviving a restart unless it is written to:
+
+- A mounted volume path
+- An external DB
+- A committed git change
+
+---
+
+## 5. Approval Escalation Path
+
+When any of the above rules require approval before proceeding:
+
+1. Post a comment on the issue describing the exact action you want to take and why.
+2. Set the issue status to `blocked`.
+3. @-mention your manager (check `chainOfCommand`) or the board user who created the task.
+4. Wait for an explicit reply approving the action before continuing.
+
+Do not interpret silence as approval. Do not retry the blocked comment on subsequent heartbeats unless new context has been added (see the blocked-task dedup rule in the Paperclip skill).
+
+---
+
+## See Also
+
+- `skills/paperclip/references/api-reference.md` — Paperclip API reference and heartbeat rules
+- `skills/paperclip/references/verifier-workflow.md` — QA verification and fix-forward process
+- Root `AGENTS.md` §6 — Code Execution Standards


### PR DESCRIPTION
## Thinking Path

PAP-803 was marked done and verified on 2026-04-16 but the commit (2784b3ea) was orphaned on a stale local branch — committed on 2026-04-15 at 12:32, nine minutes after PR #95 merged, so it never reached preview. Board approved recovery via cherry-pick on PAP-746.

## What Changed

Cherry-picks 2784b3ea:

- New file: skills/paperclip/references/safety-conventions.md covering dry-run-first, git safety rules, file-system safety, and Docker sandbox awareness
- Adds Safety Conventions section to root AGENTS.md
- Adds Safety Conventions section to default onboarding template (server/src/onboarding-assets/default/AGENTS.md)
- Adds Safety Conventions section to CEO onboarding template (server/src/onboarding-assets/ceo/AGENTS.md)

AGENTS.md had a conflict because HEAD added "Pull Request Requirements" and "Agentic Engineering References" sections after the commit was made. Resolved by preserving both sides and renumbering sections 10-14.

## Verification

- skills/paperclip/references/safety-conventions.md exists and is readable
- Root AGENTS.md Safety Conventions section references the new doc
- Both onboarding templates include a Safety section
- No conflict markers in any file

## Risks

Documentation-only change. No code paths touched.

## Model Used

Claude Opus 4.7 (1M context), provider Anthropic — agent CEO in Paperclip company.

## Checklist

- [x] Docs updated where behavior changed
- [x] No secrets committed
- [x] Cherry-picked from verified green commit
- [x] PR targets preview per CLAUDE.md branch strategy

Closes PAP-803. Recovery tracked on PAP-746.