### PR TITLE
feat(skills): vendor 6 selective skills from mattpocock/skills (PAP-862)

### DIFF
--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -711,6 +711,12 @@ function resolveBundledSkillsRoots(): BundledSkillsRootSpec[] {
       excludeSubpaths: [],
       metadataExtras: { owner: "addyosmani", repo: "agent-skills" },
     },
+    {
+      sourceKind: "paperclip_bundled_optional",
+      candidates: repoRoots.map((root) => path.resolve(root, "skills/vendor/mattpocock-skills/skills")),
+      excludeSubpaths: [],
+      metadataExtras: { owner: "mattpocock", repo: "skills" },
+    },
   ];
 }
 

--- a/skills/vendor/mattpocock-skills/VENDOR.md
+++ b/skills/vendor/mattpocock-skills/VENDOR.md
@@ -1,0 +1,133 @@
+# Vendor: mattpocock/skills (selective)
+
+This directory is a **pinned, vendored copy** of a hand-picked subset of Matt Pocock's agent-skills pack. It is NOT Paperclip-native code. Treat every file here as untrusted-until-audited content from a third party.
+
+## Upstream
+
+- Repo: <https://github.com/mattpocock/skills>
+- License: MIT
+- Pinned commit: `f71bb975bfae2dc0d31c529c7dd4a8479ecc3748`
+- Pinned date: `2026-04-29`
+- Imported into Paperclip on: `2026-04-30`
+
+## Why vendor instead of fetch-on-demand
+
+We deliberately copy the upstream content into this repo so that:
+
+1. We can audit every file before it ships to any company.
+2. A future malicious upstream commit cannot reach our agents without an explicit human bump in this repo.
+3. The Paperclip fork has zero runtime dependency on the upstream repo's availability.
+
+## Why a selective vendor (only 6 of 22 skills)
+
+Upstream ships ~22 skills. We deliberately picked the 6 below because they are high-value and **non-overlapping with our existing vendors and the Paperclip runtime model**. The rest were skipped for one of three reasons:
+
+- **Duplicates an existing vendor** (`tdd` overlaps with addyosmani's `test-driven-development`; `caveman` overlaps with the already-installed `juliusbrussee/caveman`).
+- **Assumes a different issue tracker** (`triage`, `to-prd`, `to-issues` assume GitHub/Linear and conflict with Paperclip's first-class issue model).
+- **Out of scope** (`setup-matt-pocock-skills`, `git-guardrails-claude-code`, `setup-pre-commit`, `migrate-to-shoehorn`, `scaffold-exercises`, `edit-article`, `obsidian-vault`, and the entire `deprecated/` category).
+
+When upstream adds new skills in future bumps, evaluate each one against the same scoping rules before pulling it in.
+
+## Layout
+
+```
+skills/vendor/mattpocock-skills/
+├── VENDOR.md                                                 # this file
+└── skills/                                                   # 6 SKILL.md trees (consumed by Paperclip runtime)
+    ├── engineering/
+    │   ├── diagnose/
+    │   │   ├── SKILL.md
+    │   │   └── scripts/hitl-loop.template.sh                 # benign interactive shell template
+    │   ├── grill-with-docs/
+    │   │   ├── SKILL.md
+    │   │   ├── ADR-FORMAT.md
+    │   │   └── CONTEXT-FORMAT.md
+    │   ├── improve-codebase-architecture/
+    │   │   ├── SKILL.md
+    │   │   ├── DEEPENING.md
+    │   │   ├── INTERFACE-DESIGN.md
+    │   │   └── LANGUAGE.md
+    │   └── zoom-out/SKILL.md
+    └── productivity/
+        ├── grill-me/SKILL.md
+        └── write-a-skill/SKILL.md
+```
+
+The category subdirectories (`engineering/`, `productivity/`) mirror upstream layout. The bundled-skills loader (`server/src/services/company-skills.ts → ensureBundledSkills`) walks the tree recursively and registers any directory containing a `SKILL.md`, so the categories are descriptive only and do not affect skill keys.
+
+## What we DID import
+
+- **`engineering/diagnose`** — disciplined diagnosis loop ("Phase 1 is the skill" — build a feedback loop first). Complementary to addyosmani's `debugging-and-error-recovery`; different framing.
+- **`engineering/grill-with-docs`** — interview-driven plan stress-testing tied to `CONTEXT.md` + ADRs. No equivalent in our existing vendors.
+- **`engineering/improve-codebase-architecture`** — refactor surfacing under "deepening opportunities"; complements addyosmani's `code-simplification`.
+- **`engineering/zoom-out`** — short prompt that asks the agent to step up an abstraction level. Tiny but surprisingly useful for cold-start agents.
+- **`productivity/grill-me`** — one-on-one design-grilling interviewer.
+- **`productivity/write-a-skill`** — meta-skill for authoring new agent skills.
+
+The `improve-codebase-architecture` skill cross-references files in `grill-with-docs/` (`../grill-with-docs/CONTEXT-FORMAT.md`, `../grill-with-docs/ADR-FORMAT.md`). That's why both skills must travel together — do not drop one without the other.
+
+## What we DELIBERATELY did NOT import
+
+- **Skills duplicating existing vendors:** `engineering/tdd` (have addyosmani's `test-driven-development`), `productivity/caveman` (have `juliusbrussee/caveman`).
+- **Skills assuming an external issue tracker:** `engineering/triage`, `engineering/to-prd`, `engineering/to-issues`. Paperclip's issue model is first-class; using these would create two competing sources of truth.
+- **Bootstrap / setup skills:** `engineering/setup-matt-pocock-skills` (irrelevant in vendor mode), `misc/setup-pre-commit`, `misc/git-guardrails-claude-code` (overlaps with our `CLAUDE.md` git rules).
+- **Project-specific skills:** `misc/migrate-to-shoehorn`, `misc/scaffold-exercises`.
+- **Personal skills:** `personal/edit-article`, `personal/obsidian-vault`.
+- **The entire `deprecated/` category** (`design-an-interface`, `qa`, `request-refactor-plan`, `ubiquitous-language`).
+- **Top-level project files:** `README.md`, `CLAUDE.md`, `CONTEXT.md`, `LICENSE`, `.claude-plugin/`, `.out-of-scope/`, `docs/`, `scripts/`. License is preserved in this VENDOR.md as MIT.
+
+## Runtime semantics
+
+Paperclip's bundled-skills loader (`server/src/services/company-skills.ts → ensureBundledSkills`) discovers this directory via a second `BundledSkillsRootSpec` entry (alongside the existing addyosmani entry) and:
+
+1. Inserts each of the 6 skills into every company's `company_skills` table on first access.
+2. Marks them with `metadata.sourceKind = "paperclip_bundled_optional"` and `metadata.owner = "mattpocock"` / `metadata.repo = "skills"`.
+3. Derives the canonical key `mattpocock/skills/<slug>` (e.g. `mattpocock/skills/diagnose`).
+4. **Does NOT mark them as `required: true`.** They are available to every company but only loaded into an agent's runtime prompt when the agent explicitly opts in via `adapterConfig.paperclipSkillSync.desiredSkills`.
+
+This matches the model used by the addyosmani vendor — opt-in per agent, not blanket-required.
+
+## Notes on upstream-specific frontmatter
+
+- `grill-with-docs/SKILL.md` and `zoom-out/SKILL.md` carry `disable-model-invocation: true` in their frontmatter. This is a Claude-Code-specific signal that the skill should not be auto-invoked by the model and is meant to be triggered by the user explicitly. Paperclip ignores unknown frontmatter today, so the flag is preserved verbatim and has no runtime effect on this fork. If/when Paperclip starts honouring it, it will continue to mean "user-invocation only".
+
+## Audit checklist (run on every bump)
+
+Before bumping the pinned commit, run through:
+
+- [ ] Diff the upstream against this vendored copy (`diff -ru` from a fresh clone, scoped to the 6 imported skills).
+- [ ] Inspect every changed `SKILL.md` (and any cross-referenced `*-FORMAT.md` / `LANGUAGE.md` / `DEEPENING.md` / `INTERFACE-DESIGN.md`) for prompt-injection patterns ("ignore previous instructions", obfuscated base64, hidden zero-width chars).
+- [ ] Inspect every changed shell script for `curl | sh`, `eval`, `base64 -d | sh`, exfiltration, or destructive ops outside the working tree.
+- [ ] Confirm no new file types appear (binaries, executables, archives).
+- [ ] Confirm the upstream license is still MIT (or compatible).
+- [ ] Re-evaluate any newly-added upstream skills in non-imported categories — do they now meet our scoping rules?
+- [ ] Update the pinned commit SHA and date in this file.
+- [ ] Update the layout section if upstream restructured an imported skill directory.
+
+## Bump procedure
+
+```sh
+# 1. Clone upstream at the desired commit
+git clone https://github.com/mattpocock/skills /tmp/mattpocock-skills-bump
+cd /tmp/mattpocock-skills-bump
+git checkout <new-commit-sha>
+
+# 2. Diff against current vendored copies (one per imported skill)
+for s in engineering/diagnose engineering/grill-with-docs engineering/improve-codebase-architecture engineering/zoom-out productivity/grill-me productivity/write-a-skill; do
+  diff -ru "/tmp/mattpocock-skills-bump/skills/$s" "/paperclip/workspaces/paperclip/skills/vendor/mattpocock-skills/skills/$s"
+done
+
+# 3. Run the audit checklist above on every diff hunk.
+
+# 4. Sync each imported skill, preserving VENDOR.md:
+for s in engineering/diagnose engineering/grill-with-docs engineering/improve-codebase-architecture engineering/zoom-out productivity/grill-me productivity/write-a-skill; do
+  rsync -a --delete "/tmp/mattpocock-skills-bump/skills/$s/" "/paperclip/workspaces/paperclip/skills/vendor/mattpocock-skills/skills/$s/"
+done
+
+# 5. Update this file's "Pinned commit" / "Pinned date" / "Imported into Paperclip on".
+# 6. Commit with a message that links the upstream commit and lists notable additions/removals.
+```
+
+## License (upstream)
+
+MIT — see <https://github.com/mattpocock/skills/blob/main/LICENSE>. Reproduced obligation: include the MIT license text in distributions. The full license text travels with the upstream repo; the SKILL.md files in this directory inherit those terms.

--- a/skills/vendor/mattpocock-skills/skills/engineering/diagnose/SKILL.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/diagnose/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: diagnose
+description: Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → minimise → hypothesise → instrument → fix → regression-test. Use when user says "diagnose this" / "debug this", reports a bug, says something is broken/throwing/failing, or describes a performance regression.
+---
+
+# Diagnose
+
+A discipline for hard bugs. Skip phases only when explicitly justified.
+
+When exploring the codebase, use the project's domain glossary to get a clear mental model of the relevant modules, and check ADRs in the area you're touching.
+
+## Phase 1 — Build a feedback loop
+
+**This is the skill.** Everything else is mechanical. If you have a fast, deterministic, agent-runnable pass/fail signal for the bug, you will find the cause — bisection, hypothesis-testing, and instrumentation all just consume that signal. If you don't have one, no amount of staring at code will save you.
+
+Spend disproportionate effort here. **Be aggressive. Be creative. Refuse to give up.**
+
+### Ways to construct one — try them in roughly this order
+
+1. **Failing test** at whatever seam reaches the bug — unit, integration, e2e.
+2. **Curl / HTTP script** against a running dev server.
+3. **CLI invocation** with a fixture input, diffing stdout against a known-good snapshot.
+4. **Headless browser script** (Playwright / Puppeteer) — drives the UI, asserts on DOM/console/network.
+5. **Replay a captured trace.** Save a real network request / payload / event log to disk; replay it through the code path in isolation.
+6. **Throwaway harness.** Spin up a minimal subset of the system (one service, mocked deps) that exercises the bug code path with a single function call.
+7. **Property / fuzz loop.** If the bug is "sometimes wrong output", run 1000 random inputs and look for the failure mode.
+8. **Bisection harness.** If the bug appeared between two known states (commit, dataset, version), automate "boot at state X, check, repeat" so you can `git bisect run` it.
+9. **Differential loop.** Run the same input through old-version vs new-version (or two configs) and diff outputs.
+10. **HITL bash script.** Last resort. If a human must click, drive _them_ with `scripts/hitl-loop.template.sh` so the loop is still structured. Captured output feeds back to you.
+
+Build the right feedback loop, and the bug is 90% fixed.
+
+### Iterate on the loop itself
+
+Treat the loop as a product. Once you have _a_ loop, ask:
+
+- Can I make it faster? (Cache setup, skip unrelated init, narrow the test scope.)
+- Can I make the signal sharper? (Assert on the specific symptom, not "didn't crash".)
+- Can I make it more deterministic? (Pin time, seed RNG, isolate filesystem, freeze network.)
+
+A 30-second flaky loop is barely better than no loop. A 2-second deterministic loop is a debugging superpower.
+
+### Non-deterministic bugs
+
+The goal is not a clean repro but a **higher reproduction rate**. Loop the trigger 100×, parallelise, add stress, narrow timing windows, inject sleeps. A 50%-flake bug is debuggable; 1% is not — keep raising the rate until it's debuggable.
+
+### When you genuinely cannot build a loop
+
+Stop and say so explicitly. List what you tried. Ask the user for: (a) access to whatever environment reproduces it, (b) a captured artifact (HAR file, log dump, core dump, screen recording with timestamps), or (c) permission to add temporary production instrumentation. Do **not** proceed to hypothesise without a loop.
+
+Do not proceed to Phase 2 until you have a loop you believe in.
+
+## Phase 2 — Reproduce
+
+Run the loop. Watch the bug appear.
+
+Confirm:
+
+- [ ] The loop produces the failure mode the **user** described — not a different failure that happens to be nearby. Wrong bug = wrong fix.
+- [ ] The failure is reproducible across multiple runs (or, for non-deterministic bugs, reproducible at a high enough rate to debug against).
+- [ ] You have captured the exact symptom (error message, wrong output, slow timing) so later phases can verify the fix actually addresses it.
+
+Do not proceed until you reproduce the bug.
+
+## Phase 3 — Hypothesise
+
+Generate **3–5 ranked hypotheses** before testing any of them. Single-hypothesis generation anchors on the first plausible idea.
+
+Each hypothesis must be **falsifiable**: state the prediction it makes.
+
+> Format: "If <X> is the cause, then <changing Y> will make the bug disappear / <changing Z> will make it worse."
+
+If you cannot state the prediction, the hypothesis is a vibe — discard or sharpen it.
+
+**Show the ranked list to the user before testing.** They often have domain knowledge that re-ranks instantly ("we just deployed a change to #3"), or know hypotheses they've already ruled out. Cheap checkpoint, big time saver. Don't block on it — proceed with your ranking if the user is AFK.
+
+## Phase 4 — Instrument
+
+Each probe must map to a specific prediction from Phase 3. **Change one variable at a time.**
+
+Tool preference:
+
+1. **Debugger / REPL inspection** if the env supports it. One breakpoint beats ten logs.
+2. **Targeted logs** at the boundaries that distinguish hypotheses.
+3. Never "log everything and grep".
+
+**Tag every debug log** with a unique prefix, e.g. `[DEBUG-a4f2]`. Cleanup at the end becomes a single grep. Untagged logs survive; tagged logs die.
+
+**Perf branch.** For performance regressions, logs are usually wrong. Instead: establish a baseline measurement (timing harness, `performance.now()`, profiler, query plan), then bisect. Measure first, fix second.
+
+## Phase 5 — Fix + regression test
+
+Write the regression test **before the fix** — but only if there is a **correct seam** for it.
+
+A correct seam is one where the test exercises the **real bug pattern** as it occurs at the call site. If the only available seam is too shallow (single-caller test when the bug needs multiple callers, unit test that can't replicate the chain that triggered the bug), a regression test there gives false confidence.
+
+**If no correct seam exists, that itself is the finding.** Note it. The codebase architecture is preventing the bug from being locked down. Flag this for the next phase.
+
+If a correct seam exists:
+
+1. Turn the minimised repro into a failing test at that seam.
+2. Watch it fail.
+3. Apply the fix.
+4. Watch it pass.
+5. Re-run the Phase 1 feedback loop against the original (un-minimised) scenario.
+
+## Phase 6 — Cleanup + post-mortem
+
+Required before declaring done:
+
+- [ ] Original repro no longer reproduces (re-run the Phase 1 loop)
+- [ ] Regression test passes (or absence of seam is documented)
+- [ ] All `[DEBUG-...]` instrumentation removed (`grep` the prefix)
+- [ ] Throwaway prototypes deleted (or moved to a clearly-marked debug location)
+- [ ] The hypothesis that turned out correct is stated in the commit / PR message — so the next debugger learns
+
+**Then ask: what would have prevented this bug?** If the answer involves architectural change (no good test seam, tangled callers, hidden coupling) hand off to the `/improve-codebase-architecture` skill with the specifics. Make the recommendation **after** the fix is in, not before — you have more information now than when you started.

--- a/skills/vendor/mattpocock-skills/skills/engineering/diagnose/scripts/hitl-loop.template.sh
+++ b/skills/vendor/mattpocock-skills/skills/engineering/diagnose/scripts/hitl-loop.template.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Human-in-the-loop reproduction loop.
+# Copy this file, edit the steps below, and run it.
+# The agent runs the script; the user follows prompts in their terminal.
+#
+# Usage:
+#   bash hitl-loop.template.sh
+#
+# Two helpers:
+#   step "<instruction>"          → show instruction, wait for Enter
+#   capture VAR "<question>"      → show question, read response into VAR
+#
+# At the end, captured values are printed as KEY=VALUE for the agent to parse.
+
+set -euo pipefail
+
+step() {
+  printf '\n>>> %s\n' "$1"
+  read -r -p "    [Enter when done] " _
+}
+
+capture() {
+  local var="$1" question="$2" answer
+  printf '\n>>> %s\n' "$question"
+  read -r -p "    > " answer
+  printf -v "$var" '%s' "$answer"
+}
+
+# --- edit below ---------------------------------------------------------
+
+step "Open the app at http://localhost:3000 and sign in."
+
+capture ERRORED "Click the 'Export' button. Did it throw an error? (y/n)"
+
+capture ERROR_MSG "Paste the error message (or 'none'):"
+
+# --- edit above ---------------------------------------------------------
+
+printf '\n--- Captured ---\n'
+printf 'ERRORED=%s\n' "$ERRORED"
+printf 'ERROR_MSG=%s\n' "$ERROR_MSG"

--- a/skills/vendor/mattpocock-skills/skills/engineering/grill-with-docs/ADR-FORMAT.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/skills/vendor/mattpocock-skills/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,77 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A concise description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/skills/vendor/mattpocock-skills/skills/engineering/grill-with-docs/SKILL.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/grill-with-docs/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+disable-model-invocation: true
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).

--- a/skills/vendor/mattpocock-skills/skills/engineering/improve-codebase-architecture/DEEPENING.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/skills/vendor/mattpocock-skills/skills/engineering/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/skills/vendor/mattpocock-skills/skills/engineering/improve-codebase-architecture/LANGUAGE.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/skills/vendor/mattpocock-skills/skills/engineering/improve-codebase-architecture/SKILL.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/skills/vendor/mattpocock-skills/skills/engineering/zoom-out/SKILL.md
+++ b/skills/vendor/mattpocock-skills/skills/engineering/zoom-out/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: zoom-out
+description: Tell the agent to zoom out and give broader context or a higher-level perspective. Use when you're unfamiliar with a section of code or need to understand how it fits into the bigger picture.
+disable-model-invocation: true
+---
+
+I don't know this area of code well. Go up a layer of abstraction. Give me a map of all the relevant modules and callers, using the project's domain glossary vocabulary.

--- a/skills/vendor/mattpocock-skills/skills/productivity/grill-me/SKILL.md
+++ b/skills/vendor/mattpocock-skills/skills/productivity/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/skills/vendor/mattpocock-skills/skills/productivity/write-a-skill/SKILL.md
+++ b/skills/vendor/mattpocock-skills/skills/productivity/write-a-skill/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: write-a-skill
+description: Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.
+---
+
+# Writing Skills
+
+## Process
+
+1. **Gather requirements** - ask user about:
+   - What task/domain does the skill cover?
+   - What specific use cases should it handle?
+   - Does it need executable scripts or just instructions?
+   - Any reference materials to include?
+
+2. **Draft the skill** - create:
+   - SKILL.md with concise instructions
+   - Additional reference files if content exceeds 500 lines
+   - Utility scripts if deterministic operations needed
+
+3. **Review with user** - present draft and ask:
+   - Does this cover your use cases?
+   - Anything missing or unclear?
+   - Should any section be more/less detailed?
+
+## Skill Structure
+
+```
+skill-name/
+├── SKILL.md           # Main instructions (required)
+├── REFERENCE.md       # Detailed docs (if needed)
+├── EXAMPLES.md        # Usage examples (if needed)
+└── scripts/           # Utility scripts (if needed)
+    └── helper.js
+```
+
+## SKILL.md Template
+
+```md
+---
+name: skill-name
+description: Brief description of capability. Use when [specific triggers].
+---
+
+# Skill Name
+
+## Quick start
+
+[Minimal working example]
+
+## Workflows
+
+[Step-by-step processes with checklists for complex tasks]
+
+## Advanced features
+
+[Link to separate files: See [REFERENCE.md](REFERENCE.md)]
+```
+
+## Description Requirements
+
+The description is **the only thing your agent sees** when deciding which skill to load. It's surfaced in the system prompt alongside all other installed skills. Your agent reads these descriptions and picks the relevant skill based on the user's request.
+
+**Goal**: Give your agent just enough info to know:
+
+1. What capability this skill provides
+2. When/why to trigger it (specific keywords, contexts, file types)
+
+**Format**:
+
+- Max 1024 chars
+- Write in third person
+- First sentence: what it does
+- Second sentence: "Use when [specific triggers]"
+
+**Good example**:
+
+```
+Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
+```
+
+**Bad example**:
+
+```
+Helps with documents.
+```
+
+The bad example gives your agent no way to distinguish this from other document skills.
+
+## When to Add Scripts
+
+Add utility scripts when:
+
+- Operation is deterministic (validation, formatting)
+- Same code would be generated repeatedly
+- Errors need explicit handling
+
+Scripts save tokens and improve reliability vs generated code.
+
+## When to Split Files
+
+Split into separate files when:
+
+- SKILL.md exceeds 100 lines
+- Content has distinct domains (finance vs sales schemas)
+- Advanced features are rarely needed
+
+## Review Checklist
+
+After drafting, verify:
+
+- [ ] Description includes triggers ("Use when...")
+- [ ] SKILL.md under 100 lines
+- [ ] No time-sensitive info
+- [ ] Consistent terminology
+- [ ] Concrete examples included
+- [ ] References one level deep


### PR DESCRIPTION
## Summary

- Vendor a hand-picked subset (6 of ~22) of [mattpocock/skills](https://github.com/mattpocock/skills) under `skills/vendor/mattpocock-skills/`, pinned to commit `f71bb975` (2026-04-29).
- Wire the existing bundled-skills loader (`server/src/services/company-skills.ts → resolveBundledSkillsRoots`) so it picks up the new vendor alongside the existing addyosmani vendor — `metadata.owner = "mattpocock"`, `metadata.repo = "skills"`, canonical key `mattpocock/skills/<slug>`.
- All skills surface with `sourceKind: "paperclip_bundled_optional"` (NOT required); they only load into an agent's prompt when the agent explicitly opts in via `adapterConfig.paperclipSkillSync.desiredSkills`. Same model the addyosmani vendor uses.

## Imported skills

- `engineering/diagnose` — disciplined diagnosis loop ("Phase 1 is the skill" — feedback-loop-first debugging). Complementary to addyosmani's `debugging-and-error-recovery`.
- `engineering/grill-with-docs` — interview-driven plan stress-testing tied to `CONTEXT.md` + ADRs.
- `engineering/improve-codebase-architecture` — surfaces "deepening opportunities"; complements addyosmani's `code-simplification`.
- `engineering/zoom-out` — short prompt that asks the agent to step up an abstraction level.
- `productivity/grill-me` — design-grilling interviewer.
- `productivity/write-a-skill` — meta-skill for authoring new agent skills.

## Skipped (and why)

- **Duplicate existing vendors:** `tdd` (have `addyosmani/test-driven-development`), `caveman` (have `juliusbrussee/caveman`).
- **Assume external issue tracker:** `triage`, `to-prd`, `to-issues` (Paperclip's issue model is first-class — would create competing sources of truth).
- **Bootstrap / project-specific / personal / deprecated:** `setup-matt-pocock-skills`, `git-guardrails-claude-code`, `setup-pre-commit`, `migrate-to-shoehorn`, `scaffold-exercises`, `edit-article`, `obsidian-vault`, all of `deprecated/`.

Full scoping rules + bump procedure in `skills/vendor/mattpocock-skills/VENDOR.md`.

## Audit notes

- Read every imported file. No prompt-injection patterns, no curl-pipe-sh, no exfiltration.
- Single shell script: `engineering/diagnose/scripts/hitl-loop.template.sh` — interactive bash template (`read -r -p`); no destructive ops, no network calls.
- `improve-codebase-architecture` references files in `grill-with-docs/`; both are imported, so cross-references resolve.
- `grill-with-docs` and `zoom-out` carry `disable-model-invocation: true` (Claude-Code-specific); preserved verbatim, no runtime effect on this fork.

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm test:run` — 271 files / 1581 tests pass, 1 skipped
- [x] `pnpm build` — clean
- [ ] After merge to preview, verify a fresh company picks up the 6 new skills via `GET /api/companies/:id/skills`.
- [ ] Assign `mattpocock/skills/diagnose` to a test agent via `desiredSkills` and confirm it materializes in the runtime skill set.

Issue: [PAP-862](/PAP/issues/PAP-862)

🤖 Generated with [Claude Code](https://claude.com/claude-code)