### PR TITLE
feat(chat): refine direct-chat session lifecycle (PAP-834)

### DIFF
--- a/agents/ceo/memory/2026-05-01.md
+++ b/agents/ceo/memory/2026-05-01.md
@@ -1,0 +1,20 @@
+# 2026-05-01
+
+## Timeline
+
+- **17:46Z** — User commented on PAP-834 ("Revisa el estado y si sigue siendo válido el plan, ponte con ello"). Wake reason: `issue_commented`.
+- Re-validated 2026-04-19 plan against current `preview`:
+  - Subtask 3 (session summaries + resume) shipped via PAP-861 (commit `2523b6a5`, merged via PR #110). Plan adjusted accordingly.
+  - Subtasks 1, 2, 4 still applied; line numbers drifted slightly (IDLE_TIMEOUT_MS now at chat.ts:99).
+- Stashed unrelated dirty WIP from prior session (sync-upstream/portability). Branched fresh `feat/pap-834-chat-refinements` off `preview`.
+- Implemented the three remaining items in one PR:
+  - `IDLE_TIMEOUT_MS` 5 → 15 min.
+  - `setTyping`: user typing now resets idle timer + `lastActivityAt`.
+  - `AgentChatTab`: mount-time hydrate from `chatSession()` so refresh/tab-switch doesn't drop active session.
+  - `AgentChatTab`: warn-tone toast on `chat.session.ended` for non-`user_closed` reasons.
+- Typecheck clean. Vitest 1581 passing (incl. all 11 chat-resume-and-summary tests).
+
+## Open Work
+
+- PAP-834: ready to push + open PR to `preview`.
+- PAP-7 / PAP-746 / PAP-806 / PAP-810: unchanged from prior heartbeat.

--- a/server/src/services/chat.ts
+++ b/server/src/services/chat.ts
@@ -96,7 +96,7 @@ export type SummaryFallbackHandler = (input: {
 
 // ── Constants ──────────────────────────────────────────────────────
 
-const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 const RECONNECT_GRACE_MS = 30 * 1000; // 30 second grace period after idle timeout
 
 /**
@@ -335,6 +335,10 @@ export function chatService(db?: Db) {
 
     if (isTyping) {
       typingState.set(agentId, { who, since: now() });
+      // Treat typing as activity so a user composing a long message doesn't get
+      // killed by idle timeout mid-keystroke.
+      session.lastActivityAt = now();
+      resetIdleTimer(session, () => endSession(agentId, "idle_timeout"));
     } else {
       const current = typingState.get(agentId);
       if (current?.who === who) {

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -189,7 +189,8 @@ export const agentsApi = {
     }),
   chatMessages: (id: string, after?: string, companyId?: string) =>
     api.get<unknown>(agentPath(id, companyId, `/chat-messages${after ? `?after=${encodeURIComponent(after)}` : ""}`)),
-  chatSession: (id: string, companyId?: string) => api.get<unknown>(agentPath(id, companyId, "/chat-session")),
+  chatSession: (id: string, companyId?: string) =>
+    api.get<ChatSessionData | null>(agentPath(id, companyId, "/chat-session")),
   endChatSession: (id: string, companyId?: string) =>
     api.delete<{ ok: true }>(agentPath(id, companyId, "/chat-session")),
   chatProcess: (id: string, companyId?: string) =>

--- a/ui/src/components/AgentChatTab.tsx
+++ b/ui/src/components/AgentChatTab.tsx
@@ -27,6 +27,7 @@ import { type LiveRunForIssue } from "../api/heartbeats";
 
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
 import { AgentAssistantMessage } from "./agent-message/AgentAssistantMessage";
+import { useToastActions } from "../context/ToastContext";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -325,6 +326,46 @@ export function AgentChatTab({ agent, companyId }: { agent: Agent; companyId: st
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isTypingSignaledRef = useRef(false);
 
+  const { pushToast } = useToastActions();
+
+  // Hydrate from any active session on mount / agent switch so a page refresh
+  // or tab navigation doesn't drop a running conversation. The WebSocket and
+  // REST polling effects below are gated on `sessionId`, so without this they
+  // never start until the user sends a fresh message.
+  useEffect(() => {
+    let cancelled = false;
+    agentsApi
+      .chatSession(agent.id, companyId)
+      .then((session) => {
+        if (cancelled || !session) return;
+        setSessionId((prev) => prev ?? session.id);
+        setResumedFromSessionId((prev) => prev ?? session.resumedFromSessionId ?? null);
+        setMessages((prev) => {
+          if (prev.length > 0) return prev;
+          return session.messages.map((m) => ({
+            id: m.id,
+            sessionId: m.sessionId,
+            agentId: m.agentId,
+            sender: m.sender,
+            content: m.content,
+            attachments: m.attachments,
+            readAt: m.readAt,
+            createdAt: m.createdAt,
+          }));
+        });
+        const last = session.messages[session.messages.length - 1];
+        if (last && !lastMessageIdRef.current) {
+          lastMessageIdRef.current = last.id;
+        }
+      })
+      .catch(() => {
+        // No active session, or transient error — user can still start a new one.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agent.id, companyId]);
+
   // Track the agent's active chat process while typing
   useEffect(() => {
     if (!isTyping) {
@@ -471,12 +512,34 @@ export function AgentChatTab({ agent, companyId }: { agent: Agent; companyId: st
           }
 
           if (parsed.type === "chat.session.ended") {
+            const endReason = (payload.endReason as string | null) ?? null;
             setSessionId(null);
             setResumedFromSessionId(null);
             setMessages([]);
             setIsTyping(false);
             setRemoteTyping(false);
             lastMessageIdRef.current = null;
+            // Don't surface "user_closed" — the user just clicked End and
+            // already sees the empty state. Other reasons are surprising
+            // (timeout, agent process exited) and need explanation.
+            if (endReason && endReason !== "user_closed") {
+              const title =
+                endReason === "idle_timeout"
+                  ? "Sesión finalizada por inactividad"
+                  : endReason === "agent_closed"
+                    ? "El agente cerró la sesión"
+                    : "Sesión finalizada";
+              const body =
+                endReason === "idle_timeout"
+                  ? "Puedes retomar la conversación desde el historial."
+                  : "Puedes iniciar una nueva conversación o retomar la anterior desde el historial.";
+              pushToast({
+                tone: "warn",
+                title,
+                body,
+                dedupeKey: `chat-session-ended:${agent.id}:${endReason}`,
+              });
+            }
           }
         } catch {
           // Ignore parse errors
@@ -503,7 +566,7 @@ export function AgentChatTab({ agent, companyId }: { agent: Agent; companyId: st
         socket.close(1000, "chat_tab_unmount");
       }
     };
-  }, [sessionId, companyId, agent.id, addMessageIfNew]);
+  }, [sessionId, companyId, agent.id, addMessageIfNew, pushToast]);
 
   // Fallback: slow REST polling to catch any missed messages
   useEffect(() => {


### PR DESCRIPTION
## Summary

Three usability fixes for the agent direct-chat flow surfaced by the board on [PAP-834](/PAP/issues/PAP-834). Subtask 3 (session summaries + resume) already shipped via [PAP-861](/PAP/issues/PAP-861); this PR closes the remaining three subtasks.

- **Idle timeout 5 → 15 min** (`server/src/services/chat.ts`). Composing long messages no longer kills the session.
- **Typing resets idle timer** (`chat.setTyping`). Any composer activity keeps the session alive even before the message lands.
- **Restore session on mount** (`AgentChatTab`). Hydrates from `/chat-session` so a refresh or tab switch no longer drops the running conversation. This was also the root cause of "the first user message disappears" — the WebSocket/REST effects were gated on `sessionId` and never started after a reload.
- **Session-end toast** (`AgentChatTab`). Warn-tone toast for `idle_timeout` and `agent_closed`; `user_closed` stays silent.

Plan: [PAP-834 plan](/PAP/issues/PAP-834#document-plan)

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm test:run` — 1581 passing (incl. all 11 chat-resume-and-summary tests)
- [ ] Manual on preview: open chat with an agent, type slowly for >5 min — session stays alive
- [ ] Manual on preview: refresh mid-session — messages and active state restore
- [ ] Manual on preview: let session timeout — toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)