### PR TITLE
fix(invites): hide redundant join-type toggle on landing (PAP-870)

### DIFF
--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -233,7 +233,7 @@ export function InviteLandingPage() {
           Invite expires {dateTime(invite.expiresAt)}.
         </p>
 
-        {invite.inviteType !== "bootstrap_ceo" && (
+        {invite.inviteType !== "bootstrap_ceo" && availableJoinTypes.length > 1 && (
           <div className="mt-5 flex gap-2">
             {availableJoinTypes.map((type) => (
               <button
@@ -315,7 +315,9 @@ export function InviteLandingPage() {
             ? "Submitting…"
             : invite.inviteType === "bootstrap_ceo"
               ? "Accept bootstrap invite"
-              : "Submit join request"}
+              : availableJoinTypes.length === 1
+                ? `Join as ${availableJoinTypes[0]}`
+                : "Submit join request"}
         </Button>
       </div>
     </div>

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "@/lib/router";
 import { accessApi } from "../api/access";
@@ -73,14 +73,12 @@ export function InviteLandingPage() {
     return [allowedJoinTypes] as JoinType[];
   }, [invite?.inviteType, allowedJoinTypes]);
 
-  useEffect(() => {
-    if (!availableJoinTypes.includes(joinType)) {
-      setJoinType(availableJoinTypes[0] ?? "human");
-    }
-  }, [availableJoinTypes, joinType]);
+  const effectiveJoinType: JoinType = availableJoinTypes.includes(joinType)
+    ? joinType
+    : (availableJoinTypes[0] ?? "human");
 
   const requiresAuthForHuman =
-    joinType === "human" && healthQuery.data?.deploymentMode === "authenticated" && !sessionQuery.data;
+    effectiveJoinType === "human" && healthQuery.data?.deploymentMode === "authenticated" && !sessionQuery.data;
 
   const acceptMutation = useMutation({
     mutationFn: async () => {
@@ -88,7 +86,7 @@ export function InviteLandingPage() {
       if (invite.inviteType === "bootstrap_ceo") {
         return accessApi.acceptInvite(token, { requestType: "human" });
       }
-      if (joinType === "human") {
+      if (effectiveJoinType === "human") {
         return accessApi.acceptInvite(token, { requestType: "human" });
       }
       return accessApi.acceptInvite(token, {
@@ -243,7 +241,7 @@ export function InviteLandingPage() {
                 type="button"
                 onClick={() => setJoinType(type)}
                 className={`rounded-md border px-3 py-1.5 text-sm ${
-                  joinType === type
+                  effectiveJoinType === type
                     ? "border-foreground bg-foreground text-background"
                     : "border-border bg-background text-foreground"
                 }`}
@@ -254,7 +252,7 @@ export function InviteLandingPage() {
           </div>
         )}
 
-        {joinType === "agent" && invite.inviteType !== "bootstrap_ceo" && (
+        {effectiveJoinType === "agent" && invite.inviteType !== "bootstrap_ceo" && (
           <div className="mt-4 space-y-3">
             <label className="block text-sm">
               <span className="mb-1 block text-muted-foreground">Agent name</span>
@@ -308,7 +306,7 @@ export function InviteLandingPage() {
           className="mt-5"
           disabled={
             acceptMutation.isPending ||
-            (joinType === "agent" && invite.inviteType !== "bootstrap_ceo" && agentName.trim().length === 0) ||
+            (effectiveJoinType === "agent" && invite.inviteType !== "bootstrap_ceo" && agentName.trim().length === 0) ||
             requiresAuthForHuman
           }
           onClick={() => acceptMutation.mutate()}


### PR DESCRIPTION
## Summary

Fix-forward for a UX bug surfaced while smoke-testing [PAP-869](/PAP/issues/PAP-869) on `deploy/dokploy`. When an invite is created with `allowedJoinTypes: \"human\"` the landing page rendered a single pre-selected toggle button and a separate \"Submit join request\" button — users read the toggle as a broken action and never reached the real submit.

- Hide the join-type toggle when there is only one available join type.
- Rename the submit CTA to \"Join as human\" / \"Join as agent\" when the toggle is hidden, so the visible button matches what users expect to click.
- Replace the `useEffect`+`setState` clamp for `joinType` with a derived `effectiveJoinType` (silences `react-hooks/set-state-in-effect`, no behavioural change).

Closes [PAP-870](/PAP/issues/PAP-870).

## Test plan

- [x] `pnpm -r typecheck`
- [x] `pnpm test:run` (1611 passed)
- [x] `pnpm build`
- [ ] Smoke on staging: human invite shows only one button labeled \"Join as human\" and submits on click
- [ ] Smoke on staging: agent invite shows agent form + \"Join as agent\" submit
- [ ] Smoke on staging: \"both\" invite still shows toggle + neutral \"Submit join request\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)