### PR TITLE
feat(health): expose emailEnabled in /api/health (PAP-869)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -184,6 +184,7 @@ export async function createApp(
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,
       companyDeletionEnabled: opts.companyDeletionEnabled,
+      emailEnabled: mailer.enabled,
     }),
   );
   api.use("/companies", companyRoutes(db, opts.storageService));

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -22,11 +22,13 @@ export function healthRoutes(
     deploymentExposure: DeploymentExposure;
     authReady: boolean;
     companyDeletionEnabled: boolean;
+    emailEnabled?: boolean;
   } = {
     deploymentMode: "local_trusted",
     deploymentExposure: "private",
     authReady: true,
     companyDeletionEnabled: true,
+    emailEnabled: false,
   },
 ) {
   const router = Router();
@@ -120,6 +122,7 @@ export function healthRoutes(
       bootstrapInviteActive,
       features: {
         companyDeletionEnabled: opts.companyDeletionEnabled,
+        emailEnabled: opts.emailEnabled ?? false,
       },
       ...(devServer ? { devServer } : {}),
     });


### PR DESCRIPTION
## Summary

Adds `features.emailEnabled` to `/api/health` so we can verify remotely whether the Resend mailer initialised with credentials. Same response shape, one extra boolean. Auth-gated under the existing `exposeFullDetails` rule.

Helps diagnose the PAP-869 staging issue where the user reported the email didn't arrive — currently there's no way to distinguish \"mailer is in noop mode\" from \"mailer tried and failed\" without server logs.

## Test plan

- [x] `pnpm -r typecheck`
- [x] Health tests pass
- [ ] Smoke on staging: `curl https://paperclip.srcpad.pro/api/health` returns `features.emailEnabled: true`