### PR TITLE
release: preview → deploy/dokploy (email health diagnostic, PAP-869)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -184,6 +184,7 @@ export async function createApp(
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,
       companyDeletionEnabled: opts.companyDeletionEnabled,
+      emailEnabled: mailer.enabled,
     }),
   );
   api.use("/companies", companyRoutes(db, opts.storageService));

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -22,11 +22,13 @@ export function healthRoutes(
     deploymentExposure: DeploymentExposure;
     authReady: boolean;
     companyDeletionEnabled: boolean;
+    emailEnabled?: boolean;
   } = {
     deploymentMode: "local_trusted",
     deploymentExposure: "private",
     authReady: true,
     companyDeletionEnabled: true,
+    emailEnabled: false,
   },
 ) {
   const router = Router();
@@ -120,6 +122,7 @@ export function healthRoutes(
       bootstrapInviteActive,
       features: {
         companyDeletionEnabled: opts.companyDeletionEnabled,
+        emailEnabled: opts.emailEnabled ?? false,
       },
       ...(devServer ? { devServer } : {}),
     });


### PR DESCRIPTION
Promotes the `features.emailEnabled` health flag to production so we can diagnose why the smoke-tested invite email didn't arrive on [PAP-869](/PAP/issues/PAP-869).