### PR TITLE
feat(auth): forgot-password flow with email reset link (PAP-871)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -36,6 +36,7 @@ import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { createNoopMailer, type Mailer } from "./services/email/mailer.js";
+import { createRequestPasswordResetGuard } from "./auth/reset-password.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createPluginJobScheduler } from "./services/plugin-job-scheduler.js";
@@ -170,6 +171,9 @@ export async function createApp(
     });
   });
   if (opts.betterAuthHandler) {
+    // Reject password-reset requests with a clear error when no email provider
+    // is configured, instead of Better Auth's silent generic 200.
+    app.post("/api/auth/request-password-reset", createRequestPasswordResetGuard(mailer));
     app.all("/api/auth/{*authPath}", opts.betterAuthHandler);
   }
   app.use(llmRoutes(db));

--- a/server/src/auth/__tests__/reset-password.test.ts
+++ b/server/src/auth/__tests__/reset-password.test.ts
@@ -1,0 +1,99 @@
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import type { Mailer, SendMailInput } from "../../services/email/mailer.js";
+import {
+  RESET_PASSWORD_TOKEN_TTL_SECONDS,
+  createRequestPasswordResetGuard,
+  createSendResetPassword,
+} from "../reset-password.js";
+
+function mockResponse() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as unknown as Response & { statusCode: number; body: unknown };
+}
+
+describe("createRequestPasswordResetGuard", () => {
+  it("rejects with 503 email_not_configured when the mailer is disabled", () => {
+    const guard = createRequestPasswordResetGuard({ enabled: false } as Mailer);
+    const res = mockResponse();
+    const next = vi.fn();
+
+    guard({} as Request, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({
+      error: { code: "email_not_configured", message: "Email service not configured" },
+    });
+  });
+
+  it("passes the request through when the mailer is enabled", () => {
+    const guard = createRequestPasswordResetGuard({ enabled: true } as Mailer);
+    const res = mockResponse();
+    const next = vi.fn();
+
+    guard({} as Request, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+  });
+});
+
+describe("createSendResetPassword", () => {
+  function fakeMailer(result: Awaited<ReturnType<Mailer["send"]>>) {
+    const sent: SendMailInput[] = [];
+    const mailer: Mailer = {
+      enabled: true,
+      async send(input) {
+        sent.push(input);
+        return result;
+      },
+    };
+    return { mailer, sent };
+  }
+
+  it("renders and sends the reset email with the reset url and a kind tag", async () => {
+    const { mailer, sent } = fakeMailer({ ok: true, id: "email_1" });
+    const now = () => new Date("2026-05-16T10:00:00.000Z");
+    const send = createSendResetPassword(mailer, now);
+
+    await send({
+      user: { email: "user@example.com" },
+      url: "https://app.example.com/api/auth/reset-password/tok_123?callbackURL=x",
+      token: "tok_123",
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe("user@example.com");
+    expect(sent[0].html).toContain("reset-password/tok_123");
+    expect(sent[0].text).toContain("reset-password/tok_123");
+    expect(sent[0].tags).toEqual([{ name: "kind", value: "reset_password" }]);
+    // Expiry shown in the email tracks Better Auth's token TTL.
+    const expectedExpiry = new Date(now().getTime() + RESET_PASSWORD_TOKEN_TTL_SECONDS * 1000);
+    expect(sent[0].text).toContain(expectedExpiry.toISOString().slice(0, 16).replace("T", " "));
+  });
+
+  it("throws when the mailer reports a failure so it is not silently dropped", async () => {
+    const { mailer } = fakeMailer({ ok: false, error: "Domain not verified", code: "invalid_from" });
+    const send = createSendResetPassword(mailer);
+
+    await expect(
+      send({
+        user: { email: "user@example.com" },
+        url: "https://app.example.com/api/auth/reset-password/tok_123?callbackURL=x",
+        token: "tok_123",
+      }),
+    ).rejects.toThrow("Domain not verified");
+  });
+});

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -6,6 +6,15 @@ import { toNodeHandler } from "better-auth/node";
 import type { Db } from "@paperclipai/db";
 import { authAccounts, authSessions, authUsers, authVerifications } from "@paperclipai/db";
 import type { Config } from "../config.js";
+import type { Mailer } from "../services/email/mailer.js";
+import { createSendResetPassword } from "./reset-password.js";
+
+export interface BetterAuthInstanceOptions {
+  /** Trusted origins; defaults to `deriveAuthTrustedOrigins(config)` when omitted. */
+  trustedOrigins?: string[];
+  /** Mailer used to deliver password-reset emails. When omitted, reset emails are disabled. */
+  mailer?: Mailer;
+}
 
 export type BetterAuthSessionUser = {
   id: string;
@@ -60,7 +69,11 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
   return Array.from(trustedOrigins);
 }
 
-export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?: string[]): BetterAuthInstance {
+export function createBetterAuthInstance(
+  db: Db,
+  config: Config,
+  options: BetterAuthInstanceOptions = {},
+): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
   const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET;
   if (!secret) {
@@ -69,7 +82,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
         "For local development, set BETTER_AUTH_SECRET=paperclip-dev-secret in your .env file.",
     );
   }
-  const effectiveTrustedOrigins = trustedOrigins ?? deriveAuthTrustedOrigins(config);
+  const effectiveTrustedOrigins = options.trustedOrigins ?? deriveAuthTrustedOrigins(config);
 
   const publicUrl = process.env.PAPERCLIP_PUBLIC_URL ?? baseUrl;
   const isHttpOnly = publicUrl ? publicUrl.startsWith("http://") : false;
@@ -91,6 +104,11 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
       enabled: true,
       requireEmailVerification: false,
       disableSignUp: config.authDisableSignUp,
+      // Self-service password reset. When no mailer is configured the
+      // request-password-reset route is rejected upstream by an Express guard
+      // (see createRequestPasswordResetGuard), so this callback only runs with
+      // a real mailer in practice.
+      ...(options.mailer ? { sendResetPassword: createSendResetPassword(options.mailer) } : {}),
     },
     ...(isHttpOnly ? { advanced: { useSecureCookies: false } } : {}),
   };

--- a/server/src/auth/reset-password.ts
+++ b/server/src/auth/reset-password.ts
@@ -1,0 +1,72 @@
+import type { RequestHandler } from "express";
+import type { Mailer } from "../services/email/mailer.js";
+import { renderResetPasswordEmail } from "../services/email/templates/reset-password.js";
+
+/**
+ * Reset-password token lifetime. Mirrors Better Auth's default
+ * (`emailAndPassword.resetPasswordTokenExpiresIn`, 3600s) so the expiry shown
+ * in the email matches when the token actually stops working.
+ */
+export const RESET_PASSWORD_TOKEN_TTL_SECONDS = 3600;
+
+type SendResetPasswordArgs = {
+  user: { email: string };
+  url: string;
+  token: string;
+};
+
+/**
+ * Builds the Better Auth `emailAndPassword.sendResetPassword` callback.
+ *
+ * The callback renders the reset email and sends it through the shared mailer.
+ * A failed send throws so the failure surfaces in logs/observability instead of
+ * being silently dropped — the public endpoint still returns a generic response
+ * to preserve email-enumeration protection.
+ */
+export function createSendResetPassword(
+  mailer: Mailer,
+  now: () => Date = () => new Date(),
+): (args: SendResetPasswordArgs) => Promise<void> {
+  return async ({ user, url }) => {
+    const rendered = renderResetPasswordEmail({
+      recipientEmail: user.email,
+      resetUrl: url,
+      expiresAt: new Date(now().getTime() + RESET_PASSWORD_TOKEN_TTL_SECONDS * 1000),
+    });
+    const result = await mailer.send({
+      to: user.email,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+      tags: [{ name: "kind", value: "reset_password" }],
+    });
+    if (!result.ok) {
+      throw new Error(`Failed to send password reset email: ${result.error}`);
+    }
+  };
+}
+
+/**
+ * Express guard for `POST /api/auth/request-password-reset`.
+ *
+ * Better Auth returns a generic 200 from this endpoint even when the email
+ * could not be delivered (deliberate, to avoid leaking which emails exist).
+ * That hides a misconfigured instance from operators. This guard runs *before*
+ * the Better Auth handler and rejects the request with a clear error when no
+ * email provider is configured at all. It is instance-global (not per-email),
+ * so it does not weaken email-enumeration protection.
+ */
+export function createRequestPasswordResetGuard(mailer: Mailer): RequestHandler {
+  return (_req, res, next) => {
+    if (!mailer.enabled) {
+      res.status(503).json({
+        error: {
+          code: "email_not_configured",
+          message: "Email service not configured",
+        },
+      });
+      return;
+    }
+    next();
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -461,6 +461,17 @@ export async function startServer(): Promise<StartedServer> {
     }
   }
 
+  // The mailer is created before the Better Auth instance so password-reset
+  // emails can be wired into `emailAndPassword.sendResetPassword`.
+  const mailer = createMailer({
+    resendApiKey: config.resendApiKey,
+    resendFromEmail: config.resendFromEmail,
+    resendReplyTo: config.resendReplyTo,
+  });
+  if (mailer.enabled) {
+    logger.info({ from: config.resendFromEmail }, "Resend mailer is enabled for outbound email");
+  }
+
   let authReady = config.deploymentMode === "local_trusted";
   let betterAuthHandler: RequestHandler | undefined;
   let resolveSession: ((req: ExpressRequest) => Promise<BetterAuthSessionResult | null>) | undefined;
@@ -494,7 +505,10 @@ export async function startServer(): Promise<StartedServer> {
       },
       "Authenticated mode auth origin configuration",
     );
-    const auth = createBetterAuthInstance(db as any, config, effectiveTrustedOrigins);
+    const auth = createBetterAuthInstance(db as any, config, {
+      trustedOrigins: effectiveTrustedOrigins,
+      mailer,
+    });
     betterAuthHandler = createBetterAuthHandler(auth);
     resolveSession = (req) => resolveBetterAuthSession(auth, req);
     resolveSessionFromHeaders = (headers) => resolveBetterAuthSessionFromHeaders(auth, headers);
@@ -521,14 +535,6 @@ export async function startServer(): Promise<StartedServer> {
   const feedback = feedbackService(db as any, {
     shareClient: createFeedbackTraceShareClientFromConfig(config),
   });
-  const mailer = createMailer({
-    resendApiKey: config.resendApiKey,
-    resendFromEmail: config.resendFromEmail,
-    resendReplyTo: config.resendReplyTo,
-  });
-  if (mailer.enabled) {
-    logger.info({ from: config.resendFromEmail }, "Resend mailer is enabled for outbound invite emails");
-  }
   const app = await createApp(db as any, {
     uiMode,
     serverPort: listenPort,

--- a/server/src/services/email/__tests__/reset-password-template.test.ts
+++ b/server/src/services/email/__tests__/reset-password-template.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { renderResetPasswordEmail } from "../templates/reset-password.js";
+
+describe("renderResetPasswordEmail", () => {
+  const baseInput = {
+    recipientEmail: "recipient@example.com",
+    resetUrl: "https://app.example.com/auth/reset-password?token=pcp_reset_abcd1234",
+    expiresAt: new Date("2026-05-18T12:30:00.000Z"),
+  };
+
+  it("uses a fixed Paperclip reset subject", () => {
+    const result = renderResetPasswordEmail(baseInput);
+    expect(result.subject).toBe("Restablece tu contraseña de Paperclip");
+  });
+
+  it("includes the reset URL in both html and text", () => {
+    const result = renderResetPasswordEmail(baseInput);
+    expect(result.html).toContain(baseInput.resetUrl);
+    expect(result.text).toContain(baseInput.resetUrl);
+  });
+
+  it("includes the recipient email so the reader can recognise the request", () => {
+    const result = renderResetPasswordEmail(baseInput);
+    expect(result.text).toContain("recipient@example.com");
+    expect(result.html).toContain("recipient@example.com");
+  });
+
+  it("renders the expiry timestamp with minute precision", () => {
+    const result = renderResetPasswordEmail(baseInput);
+    expect(result.text).toContain("2026-05-18 12:30 UTC");
+    expect(result.html).toContain("2026-05-18 12:30 UTC");
+  });
+
+  it("escapes HTML in the reset URL to prevent injection", () => {
+    const result = renderResetPasswordEmail({
+      ...baseInput,
+      resetUrl: 'https://app.example.com/auth/reset-password?token="><script>x</script>',
+    });
+    expect(result.html).not.toContain("<script>x</script>");
+    expect(result.html).toContain("&lt;script&gt;");
+  });
+
+  it("keeps a safe-to-ignore footer for unsolicited resets", () => {
+    const result = renderResetPasswordEmail(baseInput);
+    expect(result.text).toContain("puedes ignorar este correo");
+    expect(result.html).toContain("puedes ignorar este correo");
+  });
+});

--- a/server/src/services/email/templates/reset-password.ts
+++ b/server/src/services/email/templates/reset-password.ts
@@ -1,0 +1,84 @@
+import type { RenderedEmail } from "./invite.js";
+
+export interface ResetPasswordEmailInput {
+  recipientEmail: string;
+  resetUrl: string;
+  expiresAt: Date;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatExpiresAt(date: Date): string {
+  // Minute precision — reset links are short-lived (default 1h).
+  return `${date.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}
+
+export function renderResetPasswordEmail(input: ResetPasswordEmailInput): RenderedEmail {
+  const expiresOn = formatExpiresAt(input.expiresAt);
+  const subject = "Restablece tu contraseña de Paperclip";
+
+  const safeUrl = escapeHtml(input.resetUrl);
+  const safeExpires = escapeHtml(expiresOn);
+  const safeRecipient = escapeHtml(input.recipientEmail);
+
+  const text = [
+    "Restablece tu contraseña de Paperclip",
+    "",
+    `Se ha solicitado un restablecimiento de contraseña para ${input.recipientEmail}.`,
+    `Abre este link para elegir una nueva contraseña (válido hasta ${expiresOn}):`,
+    input.resetUrl,
+    "",
+    "Si no solicitaste este cambio puedes ignorar este correo — tu contraseña no cambiará.",
+    "",
+    "— Paperclip",
+  ].join("\n");
+
+  const html = `<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>${escapeHtml(subject)}</title>
+  </head>
+  <body style="margin:0;padding:0;background:#f5f5f7;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1a1a1a;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:520px;background:#ffffff;border-radius:12px;padding:32px;">
+            <tr>
+              <td>
+                <p style="margin:0 0 8px;font-size:14px;color:#6b7280;letter-spacing:0.04em;text-transform:uppercase;">Paperclip</p>
+                <h1 style="margin:0 0 16px;font-size:22px;line-height:1.35;font-weight:600;">Restablece tu contraseña</h1>
+                <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#374151;">
+                  Se ha solicitado un restablecimiento de contraseña para <strong>${safeRecipient}</strong>. Pulsa el botón para elegir una nueva contraseña. El link es válido hasta el <strong>${safeExpires}</strong>.
+                </p>
+                <p style="margin:0 0 24px;">
+                  <a href="${safeUrl}" style="display:inline-block;background:#111827;color:#ffffff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:8px;">Restablecer contraseña</a>
+                </p>
+                <p style="margin:0 0 12px;font-size:13px;color:#6b7280;">
+                  Si el botón no funciona, copia y pega esta URL en tu navegador:
+                </p>
+                <p style="margin:0 0 24px;font-size:13px;word-break:break-all;">
+                  <a href="${safeUrl}" style="color:#2563eb;text-decoration:underline;">${safeUrl}</a>
+                </p>
+                <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;" />
+                <p style="margin:0;font-size:12px;color:#9ca3af;">
+                  Si no solicitaste este cambio puedes ignorar este correo — tu contraseña no cambiará.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  return { subject, html, text };
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -41,6 +41,8 @@ import { RunTranscriptUxLab } from "./pages/RunTranscriptUxLab";
 import { OrgChart } from "./pages/OrgChart";
 import { NewAgent } from "./pages/NewAgent";
 import { AuthPage } from "./pages/Auth";
+import { ForgotPasswordPage } from "./pages/ForgotPassword";
+import { ResetPasswordPage } from "./pages/ResetPassword";
 import { BoardClaimPage } from "./pages/BoardClaim";
 import { CliAuthPage } from "./pages/CliAuth";
 import { InviteLandingPage } from "./pages/InviteLanding";
@@ -304,6 +306,8 @@ export function App() {
     <>
       <Routes>
         <Route path="auth" element={<AuthPage />} />
+        <Route path="auth/forgot-password" element={<ForgotPasswordPage />} />
+        <Route path="auth/reset-password" element={<ResetPasswordPage />} />
         <Route path="board-claim/:token" element={<BoardClaimPage />} />
         <Route path="cli-auth/:id" element={<CliAuthPage />} />
         <Route path="invite/:token" element={<InviteLandingPage />} />

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -71,4 +71,16 @@ export const authApi = {
   signOut: async () => {
     await authPost("/sign-out", {});
   },
+
+  // Sends a password-reset email. The server responds generically regardless of
+  // whether the email exists (email-enumeration protection); it only throws
+  // when no email provider is configured ("Email service not configured").
+  requestPasswordReset: async (input: { email: string; redirectTo: string }) => {
+    await authPost("/request-password-reset", input);
+  },
+
+  // Completes a password reset using the token from the email link.
+  resetPassword: async (input: { token: string; newPassword: string }) => {
+    await authPost("/reset-password", input);
+  },
 };

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useSearchParams } from "@/lib/router";
+import { Link, useNavigate, useSearchParams } from "@/lib/router";
 import { authApi } from "../api/auth";
 import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
@@ -133,9 +133,19 @@ export function AuthPage() {
               />
             </div>
             <div>
-              <label htmlFor="password" className="text-xs text-muted-foreground mb-1 block">
-                Password
-              </label>
+              <div className="flex items-center justify-between mb-1">
+                <label htmlFor="password" className="text-xs text-muted-foreground">
+                  Password
+                </label>
+                {mode === "sign_in" && (
+                  <Link
+                    to="/auth/forgot-password"
+                    className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                  >
+                    Forgot password?
+                  </Link>
+                )}
+              </div>
               <input
                 id="password"
                 name="password"

--- a/ui/src/pages/ForgotPassword.tsx
+++ b/ui/src/pages/ForgotPassword.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Link } from "@/lib/router";
+import { authApi } from "../api/auth";
+import { Button } from "@/components/ui/button";
+import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
+import { Sparkles } from "lucide-react";
+
+export function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      await authApi.requestPasswordReset({
+        email: email.trim(),
+        redirectTo: `${window.location.origin}/auth/reset-password`,
+      });
+    },
+    onSuccess: () => setError(null),
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "Could not send the reset email.");
+    },
+  });
+
+  const canSubmit = email.trim().length > 0;
+  const submitted = mutation.isSuccess;
+
+  return (
+    <div className="fixed inset-0 flex bg-background">
+      <div className="w-full md:w-1/2 flex flex-col overflow-y-auto">
+        <div className="w-full max-w-md mx-auto my-auto px-8 py-12">
+          <div className="flex items-center gap-2 mb-8">
+            <Sparkles className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">Paperclip</span>
+          </div>
+
+          <h1 className="text-xl font-semibold">Forgot your password?</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Enter your account email and we'll send you a link to choose a new password.
+          </p>
+
+          {submitted ? (
+            <div className="mt-6 space-y-4">
+              <p className="rounded-md border border-border bg-muted/40 px-3 py-3 text-sm text-foreground">
+                If <span className="font-medium">{email.trim()}</span> is registered, a password reset link is on its
+                way. Check your inbox (and spam folder).
+              </p>
+              <Link to="/auth" className="text-sm font-medium text-foreground underline underline-offset-2">
+                Back to sign in
+              </Link>
+            </div>
+          ) : (
+            <>
+              <form
+                className="mt-6 space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  if (mutation.isPending) return;
+                  if (!canSubmit) {
+                    setError("Please enter your email.");
+                    return;
+                  }
+                  mutation.mutate();
+                }}
+              >
+                <div>
+                  <label htmlFor="email" className="text-xs text-muted-foreground mb-1 block">
+                    Email
+                  </label>
+                  <input
+                    id="email"
+                    name="email"
+                    className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    autoComplete="email"
+                    autoFocus
+                  />
+                </div>
+                {error && <p className="text-xs text-destructive">{error}</p>}
+                <Button
+                  type="submit"
+                  disabled={mutation.isPending}
+                  aria-disabled={!canSubmit || mutation.isPending}
+                  className={`w-full ${!canSubmit && !mutation.isPending ? "opacity-50" : ""}`}
+                >
+                  {mutation.isPending ? "Sending…" : "Send reset link"}
+                </Button>
+              </form>
+
+              <div className="mt-5 text-sm text-muted-foreground">
+                Remembered it?{" "}
+                <Link to="/auth" className="font-medium text-foreground underline underline-offset-2">
+                  Sign in
+                </Link>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="hidden md:block w-1/2 overflow-hidden">
+        <AsciiArtAnimation />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/ResetPassword.tsx
+++ b/ui/src/pages/ResetPassword.tsx
@@ -1,0 +1,162 @@
+import { useState, type ReactNode } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Link, useNavigate, useSearchParams } from "@/lib/router";
+import { authApi } from "../api/auth";
+import { Button } from "@/components/ui/button";
+import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
+import { Sparkles } from "lucide-react";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  // Better Auth's link-verification step redirects here with ?error=INVALID_TOKEN
+  // when the token is missing or expired.
+  const linkError = searchParams.get("error");
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!token) throw new Error("Missing reset token.");
+      await authApi.resetPassword({ token, newPassword: password });
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "Could not reset your password.");
+    },
+  });
+
+  const tokenInvalid = !token || Boolean(linkError);
+
+  const canSubmit = password.length >= MIN_PASSWORD_LENGTH && confirm.length > 0 && password === confirm;
+
+  const shell = (children: ReactNode) => (
+    <div className="fixed inset-0 flex bg-background">
+      <div className="w-full md:w-1/2 flex flex-col overflow-y-auto">
+        <div className="w-full max-w-md mx-auto my-auto px-8 py-12">
+          <div className="flex items-center gap-2 mb-8">
+            <Sparkles className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">Paperclip</span>
+          </div>
+          {children}
+        </div>
+      </div>
+      <div className="hidden md:block w-1/2 overflow-hidden">
+        <AsciiArtAnimation />
+      </div>
+    </div>
+  );
+
+  if (tokenInvalid) {
+    return shell(
+      <>
+        <h1 className="text-xl font-semibold">Reset link invalid</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          This password reset link is missing, invalid, or has expired. Request a new one to continue.
+        </p>
+        <div className="mt-6">
+          <Link to="/auth/forgot-password">
+            <Button className="w-full">Request a new reset link</Button>
+          </Link>
+        </div>
+        <div className="mt-5 text-sm text-muted-foreground">
+          <Link to="/auth" className="font-medium text-foreground underline underline-offset-2">
+            Back to sign in
+          </Link>
+        </div>
+      </>,
+    );
+  }
+
+  if (mutation.isSuccess) {
+    return shell(
+      <>
+        <h1 className="text-xl font-semibold">Password updated</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Your password has been changed. You can now sign in with your new password.
+        </p>
+        <div className="mt-6">
+          <Button className="w-full" onClick={() => navigate("/auth", { replace: true })}>
+            Go to sign in
+          </Button>
+        </div>
+      </>,
+    );
+  }
+
+  return shell(
+    <>
+      <h1 className="text-xl font-semibold">Choose a new password</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Pick a password with at least {MIN_PASSWORD_LENGTH} characters.
+      </p>
+
+      <form
+        className="mt-6 space-y-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (mutation.isPending) return;
+          if (password.length < MIN_PASSWORD_LENGTH) {
+            setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+            return;
+          }
+          if (password !== confirm) {
+            setError("Passwords do not match.");
+            return;
+          }
+          setError(null);
+          mutation.mutate();
+        }}
+      >
+        <div>
+          <label htmlFor="password" className="text-xs text-muted-foreground mb-1 block">
+            New password
+          </label>
+          <input
+            id="password"
+            name="password"
+            className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            autoComplete="new-password"
+            autoFocus
+          />
+        </div>
+        <div>
+          <label htmlFor="confirm" className="text-xs text-muted-foreground mb-1 block">
+            Confirm new password
+          </label>
+          <input
+            id="confirm"
+            name="confirm"
+            className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+            type="password"
+            value={confirm}
+            onChange={(event) => setConfirm(event.target.value)}
+            autoComplete="new-password"
+          />
+        </div>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <Button
+          type="submit"
+          disabled={mutation.isPending}
+          aria-disabled={!canSubmit || mutation.isPending}
+          className={`w-full ${!canSubmit && !mutation.isPending ? "opacity-50" : ""}`}
+        >
+          {mutation.isPending ? "Updating…" : "Update password"}
+        </Button>
+      </form>
+
+      <div className="mt-5 text-sm text-muted-foreground">
+        <Link to="/auth" className="font-medium text-foreground underline underline-offset-2">
+          Back to sign in
+        </Link>
+      </div>
+    </>,
+  );
+}


### PR DESCRIPTION
## Summary

Self-service password recovery for board users, built on Better Auth's email/password support and the existing Resend mailer (from PAP-869). Closes the gap surfaced during the PAP-869 smoke test: a user who forgot their password previously had no recovery path.

## What's included

**Server**
- `reset-password.ts` email template (HTML + plain text), sibling to `invite.ts`.
- `createSendResetPassword` wires Better Auth's `emailAndPassword.sendResetPassword` to the shared mailer. The mailer is now created **before** the Better Auth instance so it can be injected.
- `createRequestPasswordResetGuard` mounted on `POST /api/auth/request-password-reset`: returns a clear `503 email_not_configured` ("Email service not configured") when no mailer is configured, instead of Better Auth's silent generic `200`. The guard is instance-global, so email-enumeration protection is preserved.

**UI**
- `/auth/forgot-password` — request a reset link (generic confirmation, no email enumeration).
- `/auth/reset-password` — choose a new password; handles missing/expired tokens.
- "Forgot password?" link on the sign-in form.
- `authApi.requestPasswordReset` / `authApi.resetPassword` helpers.

## Done criteria mapping

| # | Criterion | Status |
|---|-----------|--------|
| 1 | "Forgot password?" → enter email → receive email | ✅ |
| 2 | Link → `/auth/reset-password?token=...` → set new password | ✅ |
| 3 | Sign in with new password | ✅ (Better Auth `reset-password`) |
| 4 | Old password invalidated | ✅ (Better Auth updates the credential account) |
| 5 | Reset tokens expire | ✅ Better Auth default 1h (`RESET_PASSWORD_TOKEN_TTL_SECONDS`) |
| 6 | No `RESEND_API_KEY` → clear error, no silent fail | ✅ `503 email_not_configured` guard |
| 7 | `typecheck` / `test:run` / `build` green | ✅ all pass locally |

## Notes

- Better Auth 1.4.18 names the request endpoint `/request-password-reset` (the plan referenced the older `/forget-password` name). Behaviour is unchanged.
- Smoke on staging still pending (criterion in the issue scope) — needs `RESEND_API_KEY` + `RESEND_FROM_EMAIL` configured on `preview`.

## Tests

- `reset-password-template.test.ts` — template rendering + HTML escaping.
- `auth/__tests__/reset-password.test.ts` — `sendResetPassword` wiring (payload + failure surfacing) and the `email_not_configured` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)